### PR TITLE
[EDMT-115] 학생 생성 모달창 구현 및 mock api 연동

### DIFF
--- a/src/components/modal/create-record-modal.tsx
+++ b/src/components/modal/create-record-modal.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+import { Input } from '@/components/input/input';
+import { useCreateRecord } from '@/hooks/api/use-create-record';
+import type { RecordType } from '@/types/api/student-record';
+
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalOverlay,
+  ModalPortal,
+} from './base-modal';
+
+interface CreateRecordModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  recordType: RecordType;
+}
+
+export default function CreateRecordModal({
+  open,
+  onOpenChange,
+  recordType,
+}: CreateRecordModalProps) {
+  const countInputRef = useRef<HTMLInputElement>(null);
+
+  const [studentCount, setStudentCount] = useState(0);
+
+  const studentNumberRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const nameRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const { mutate: createRecords } = useCreateRecord();
+
+  const handleRegister = () => {
+    const count = Number(countInputRef.current?.value || 0);
+    if (count <= 0) return;
+
+    setStudentCount(count);
+  };
+
+  const handleSubmit = () => {
+    const students = Array.from({ length: studentCount }, (_, index) => ({
+      studentNumber: studentNumberRefs.current[index]?.value || '',
+      name: nameRefs.current[index]?.value || '',
+    }));
+
+    createRecords({ recordType, students });
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setStudentCount(0);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal open={open} onOpenChange={handleClose}>
+      <ModalPortal>
+        <ModalOverlay />
+        <ModalContent aria-describedby={undefined} className="max-w-xl rounded-xl px-16 py-5 pt-10">
+          <ModalHeader className="w-full">
+            <ModalTitle className="mb-5 flex items-center justify-center gap-2 text-[24px]">
+              <span>학생</span>
+              <Input
+                type="text"
+                ref={countInputRef}
+                className="ml-2 w-20 p-2 pt-3 text-right"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleRegister();
+                  }
+                }}
+              />
+              <span>명</span>
+              <button
+                onClick={handleRegister}
+                className="ml-2 rounded-md bg-blue-800 px-4 pb-1.5 pt-2 text-[16px] font-bold text-white hover:bg-blue-950"
+              >
+                등록
+              </button>
+            </ModalTitle>
+          </ModalHeader>
+          <div className="max-h-96 min-h-96 w-full overflow-y-auto rounded-xl bg-slate-100 p-5">
+            {Array.from({ length: studentCount }, (_, index) => (
+              <div
+                key={index}
+                className="mb-2 flex items-center justify-center gap-2 rounded-xl bg-slate-700 p-2"
+              >
+                <span className="w-8 text-white">{index + 1}</span>
+                <Input
+                  type="text"
+                  placeholder="학번"
+                  ref={(studentNumber) => {
+                    studentNumberRefs.current[index] = studentNumber;
+                  }}
+                  className="text-white placeholder:text-slate-400"
+                />
+                <Input
+                  type="text"
+                  placeholder="이름"
+                  ref={(name) => {
+                    nameRefs.current[index] = name;
+                  }}
+                  className="text-white placeholder:text-slate-400"
+                />
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={handleSubmit}
+            className="mt-5 rounded-md bg-blue-800 px-4 py-2 font-bold text-white hover:bg-blue-950"
+          >
+            생성하기
+          </button>
+        </ModalContent>
+      </ModalPortal>
+    </Modal>
+  );
+}

--- a/src/components/record/empty-record.tsx
+++ b/src/components/record/empty-record.tsx
@@ -1,11 +1,26 @@
-export default function EmptyRecord() {
+'use client';
+
+import { useState } from 'react';
+
+import type { RecordType } from '@/types/api/student-record';
+
+import CreateRecordModal from '../modal/create-record-modal';
+
+export default function EmptyRecord({ recordType }: { recordType: RecordType }) {
+  const [open, setOpen] = useState(false);
+
   return (
     <>
       <p className="text-[20px] font-bold">아직 등록된 생활기록부가 없어요</p>
-      <button className="rounded-lg bg-slate-800 px-10 py-4 text-[20px] font-bold text-white hover:bg-slate-950">
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-lg bg-slate-800 px-10 py-4 text-[20px] font-bold text-white hover:bg-slate-950"
+      >
         학생 등록하고
         <br /> 생활기록부 관리하기
       </button>
+
+      <CreateRecordModal open={open} onOpenChange={setOpen} recordType={recordType} />
     </>
   );
 }

--- a/src/components/record/record-body.tsx
+++ b/src/components/record/record-body.tsx
@@ -22,7 +22,7 @@ export default function RecordBody({ recordType }: { recordType: RecordType }) {
   } else if (isError || !data) {
     content = <p className="text-[20px] font-bold">데이터를 불러오는 데 실패했습니다.</p>;
   } else if (data.length === 0) {
-    content = <EmptyRecord />;
+    content = <EmptyRecord recordType={recordType} />;
   }
 
   if (content) {

--- a/src/hooks/api/use-create-record.ts
+++ b/src/hooks/api/use-create-record.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { createRecords } from '@/services/student-manage/create-record';
+import type { Response } from '@/types/api/response';
+import type { CreateRecord } from '@/types/api/student-record';
+
+export const useCreateRecord = () => {
+  return useMutation<Response<null>, Error, CreateRecord>({
+    mutationFn: createRecords,
+    onSuccess: (data) => {
+      console.log('생기부 데이터 생성 성공:', data);
+    },
+    onError: (error) => {
+      console.error('생기부 데이터 생성 실패:', error.message);
+    },
+  });
+};

--- a/src/mocks/handlers/create-record.ts
+++ b/src/mocks/handlers/create-record.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw';
+
+import type { CreateRecord } from '@/types/api/student-record';
+
+export const createRecords = [
+  http.post('/api/v1/create-student-records', async ({ request }) => {
+    const body = (await request.json()) as CreateRecord;
+
+    if (!body || !Array.isArray(body.students) || body.students.length === 0) {
+      return HttpResponse.json(
+        { status: 400, code: 'EDMT-40001', message: '잘못된 요청 데이터' },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json({
+      status: 200,
+      code: 'EDMT-20000',
+      message: '학생 기록이 성공적으로 등록되었습니다.',
+    });
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,6 +1,13 @@
 import { authHandler } from './auth-handler';
+import { createRecords } from './create-record';
 import { getNoticeDetail } from './get-notice-detail';
 import { getNoticeList } from './get-notice-list';
 import { getRecord } from './get-record';
 
-export const handlers = [...authHandler, ...getRecord, ...getNoticeList, ...getNoticeDetail];
+export const handlers = [
+  ...authHandler,
+  ...getRecord,
+  ...getNoticeList,
+  ...getNoticeDetail,
+  ...createRecords,
+];

--- a/src/services/student-manage/create-record.ts
+++ b/src/services/student-manage/create-record.ts
@@ -1,0 +1,26 @@
+import type { Response } from '@/types/api/response';
+import type { RecordType, CreateStudentRecord } from '@/types/api/student-record';
+
+export const createRecords = async ({
+  recordType,
+  students,
+}: {
+  recordType: RecordType;
+  students: CreateStudentRecord[];
+}): Promise<Response<null>> => {
+  const res = await fetch('/api/v1/create-student-records', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ recordType, students }),
+  });
+
+  const json: Response<null> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '학생 기록 생성 실패');
+  }
+
+  return json;
+};

--- a/src/types/api/student-record.ts
+++ b/src/types/api/student-record.ts
@@ -6,3 +6,13 @@ export type StudentRecord = {
   name: string;
   content: string;
 };
+
+export type CreateStudentRecord = {
+  name: string;
+  studentNumber: string;
+};
+
+export type CreateRecord = {
+  recordType: RecordType;
+  students: CreateStudentRecord[];
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-115]

## 🌱 주요 변경 사항

1. 초기 생기부 데이터 없을때 학생을 생성하는 modal 구현
2. 생기부 데이터 없을때 보여주는 컴포넌트에 open 트리거 추가, modal에 주입할 type 추가
3. 생기부 생성하는 post api 로직 구현 및 tanstack query Mutation함수로 추상화
4. 생기부 생성하는 mock post api 구현

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/03eabf04-107d-4e53-b8fe-be14529ab9e6

