### PR TITLE
[EDMT-149] 회원가입 로직 api 연동 및 이메일 페이지 구현

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,10 +1,10 @@
-import SignUp from '@/components/signup/signup';
+import Signup from '@/components/signup/signup';
 
 export default function Page() {
   return (
     <div className="flex w-full flex-col items-center justify-center gap-4">
       <h2 className="text-[26px] font-bold">회원가입</h2>
-      <SignUp />
+      <Signup />
     </div>
   );
 }

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,10 +1,11 @@
+import { Suspense } from 'react';
+
 import VerifyEmail from '@/components/verify-email/verify-email';
 
 export default function Page() {
   return (
-    <div className="flex flex-col gap-10 text-center">
-      <h1>이메일 인증 확인 페이지</h1>
+    <Suspense fallback={<div>Loading...</div>}>
       <VerifyEmail />
-    </div>
+    </Suspense>
   );
 }

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,5 +1,10 @@
 import VerifyEmail from '@/components/verify-email/verify-email';
 
 export default function Page() {
-  return <VerifyEmail />;
+  return (
+    <div className="flex flex-col gap-10 text-center">
+      <h1>이메일 인증 확인 페이지</h1>
+      <VerifyEmail />
+    </div>
+  );
 }

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,11 +1,12 @@
-import { Suspense } from 'react';
-
 import VerifyEmail from '@/components/verify-email/verify-email';
 
-export default function Page() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <VerifyEmail />
-    </Suspense>
-  );
+interface PageProps {
+  searchParams: {
+    email?: string;
+    token?: string;
+  };
+}
+
+export default function VerifyEmailPage({ searchParams }: PageProps) {
+  return <VerifyEmail email={searchParams.email} token={searchParams.token} />;
 }

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,5 @@
+import VerifyEmail from '@/components/verify-email/verify-email';
+
+export default function Page() {
+  return <VerifyEmail />;
+}

--- a/src/components/signup/signup-scheme.ts
+++ b/src/components/signup/signup-scheme.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { allowedDomains } from '@/constants/signup-data';
 
-export const signUpScheme = z
+export const signupScheme = z
   .object({
     email: z
       .string()
@@ -45,4 +45,4 @@ export const signUpScheme = z
     message: '비밀번호가 일치하지 않습니다.',
   });
 
-export type SignUpDataType = z.infer<typeof signUpScheme>;
+export type SignupDataType = z.infer<typeof signupScheme>;

--- a/src/components/signup/signup.tsx
+++ b/src/components/signup/signup.tsx
@@ -14,7 +14,7 @@ import { signupScheme } from './signup-scheme';
 import type { SignupDataType } from './signup-scheme';
 
 export default function Signup() {
-  const { mutate: signup } = useSignup();
+  const { mutate: signup, isPending } = useSignup();
 
   const {
     register,
@@ -247,6 +247,7 @@ export default function Signup() {
       <button
         type="submit"
         className="mt-4 h-12 rounded-md bg-slate-800 font-semibold text-white hover:bg-slate-950"
+        disabled={isPending}
       >
         가입하기
       </button>

--- a/src/components/signup/signup.tsx
+++ b/src/components/signup/signup.tsx
@@ -7,20 +7,23 @@ import { useForm } from 'react-hook-form';
 
 import { Input } from '@/components/input/input';
 import { subjects } from '@/constants/signup-data';
+import { useSignup } from '@/hooks/api/use-signup';
 
-import { signUpScheme } from './signup-scheme';
+import { signupScheme } from './signup-scheme';
 
-import type { SignUpDataType } from './signup-scheme';
+import type { SignupDataType } from './signup-scheme';
 
-export default function SignUp() {
+export default function Signup() {
+  const { mutate: signup } = useSignup();
+
   const {
     register,
     formState: { errors },
     handleSubmit,
     setValue,
     watch,
-  } = useForm<SignUpDataType>({
-    resolver: zodResolver(signUpScheme),
+  } = useForm<SignupDataType>({
+    resolver: zodResolver(signupScheme),
     defaultValues: {
       email: '',
       password: '',
@@ -31,8 +34,10 @@ export default function SignUp() {
     mode: 'onChange',
   });
 
-  const onSubmit = (data: SignUpDataType) => {
-    console.log(data);
+  const onSubmit = (data: SignupDataType) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { confirmPassword, ...signupData } = data;
+    signup(signupData);
   };
 
   const selectedSubjectValue = watch('subject');

--- a/src/components/verify-email/verify-email.tsx
+++ b/src/components/verify-email/verify-email.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+
+import { useGetVerifyEmail } from '@/hooks/api/use-get-verify-email';
+
+export default function VerifyEmail() {
+  const searchParams = useSearchParams();
+
+  const token = searchParams.get('token');
+  const email = searchParams.get('email');
+
+  const [message, setMessage] = useState('');
+
+  const { mutate: getVerifyEmail } = useGetVerifyEmail();
+
+  useEffect(() => {
+    if (email && token) {
+      setMessage('이메일 인증 중...');
+      getVerifyEmail({ email, token });
+    } else if (email) {
+      setMessage(`가입하신 ${email} 주소로 인증 메일을 보냈습니다. 메일함을 확인해주세요.`);
+    } else {
+      setMessage('잘못된 접근입니다.');
+    }
+  }, [email, token, getVerifyEmail]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold">{message}</h1>
+    </div>
+  );
+}

--- a/src/components/verify-email/verify-email.tsx
+++ b/src/components/verify-email/verify-email.tsx
@@ -2,26 +2,23 @@
 
 import { useEffect, useState } from 'react';
 
-import { useSearchParams } from 'next/navigation';
-
 import { useGetVerifyEmail } from '@/hooks/api/use-get-verify-email';
 
-export default function VerifyEmail() {
-  const searchParams = useSearchParams();
+interface VerifyEmailProps {
+  email?: string;
+  token?: string;
+}
 
-  const token = searchParams.get('token');
-  const email = searchParams.get('email');
-
-  const [message, setMessage] = useState('');
-
+export default function VerifyEmail({ email, token }: VerifyEmailProps) {
   const { mutate: getVerifyEmail } = useGetVerifyEmail();
+  const [message, setMessage] = useState('');
 
   useEffect(() => {
     if (email && token) {
       setMessage('이메일 인증 중...');
       getVerifyEmail({ email, token });
     } else if (email) {
-      setMessage(`가입하신 ${email} 주소로 인증 메일을 보냈습니다. 메일함을 확인해주세요.`);
+      setMessage(`${email} 주소로 인증 메일을 보냈습니다.`);
     } else {
       setMessage('잘못된 접근입니다.');
     }

--- a/src/hooks/api/use-get-verify-email.ts
+++ b/src/hooks/api/use-get-verify-email.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useRouter } from 'next/navigation';
+
+import { getVerifyEmail } from '@/services/auth/get-verify-email';
+import type { Response } from '@/types/api/response';
+
+export const useGetVerifyEmail = () => {
+  const router = useRouter();
+
+  return useMutation<Response<null>, Error, { email: string; token: string }>({
+    mutationFn: ({ email, token }) => getVerifyEmail(email, token),
+    onSuccess: (data) => {
+      console.log('인증 성공:', data);
+      setTimeout(() => {
+        router.push('/');
+      }, 1000);
+    },
+    onError: (error) => {
+      console.error('이메일 인증 실패:', error.message);
+    },
+  });
+};

--- a/src/hooks/api/use-get-verify-email.ts
+++ b/src/hooks/api/use-get-verify-email.ts
@@ -12,9 +12,7 @@ export const useGetVerifyEmail = () => {
     mutationFn: ({ email, token }) => getVerifyEmail(email, token),
     onSuccess: (data) => {
       console.log('인증 성공:', data);
-      setTimeout(() => {
-        router.push('/');
-      }, 1000);
+      router.replace('/');
     },
     onError: (error) => {
       console.error('이메일 인증 실패:', error.message);

--- a/src/hooks/api/use-signup.ts
+++ b/src/hooks/api/use-signup.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useRouter } from 'next/navigation';
+
+import { signup } from '@/services/auth/signup';
+import type { SignupTypes } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const useSignup = () => {
+  const router = useRouter();
+
+  return useMutation<Response<null>, Error, SignupTypes>({
+    mutationFn: signup,
+    onSuccess: (data, variables) => {
+      console.log(data);
+      router.push(`/verify-email?email=${encodeURIComponent(variables.email)}`);
+    },
+    onError: (error) => {
+      console.error('회원가입 실패:', error.message);
+      alert(error.message);
+    },
+  });
+};

--- a/src/mocks/handlers/get-verify-email.ts
+++ b/src/mocks/handlers/get-verify-email.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 export const getVerifyEmail = [
-  http.get('api/v1/auth/verify-email', ({ request }) => {
+  http.get('/api/v1/auth/verify-email', ({ request }) => {
     const url = new URL(request.url);
     const email = url.searchParams.get('email');
     const token = url.searchParams.get('token');

--- a/src/mocks/handlers/get-verify-email.ts
+++ b/src/mocks/handlers/get-verify-email.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from 'msw';
+
+export const getVerifyEmail = [
+  http.get('api/v1/auth/verify-email', ({ request }) => {
+    const url = new URL(request.url);
+    const email = url.searchParams.get('email');
+    const token = url.searchParams.get('token');
+
+    if (email === 'test@naver.com' && token === 'abc') {
+      return HttpResponse.json({
+        status: 200,
+        code: 'EDMT-20002',
+        message: '이메일 인증이 완료되었습니다.',
+      });
+    }
+
+    return HttpResponse.json(
+      {
+        status: 400,
+        code: 'EDMT-40003',
+        message: '인증 토큰이 유효하지 않습니다.',
+      },
+      { status: 400 },
+    );
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -5,6 +5,8 @@ import { deleteRecordDetail } from './delete-record-detail';
 import { getNoticeDetail } from './get-notice-detail';
 import { getNoticeList } from './get-notice-list';
 import { getRecord } from './get-record';
+import { getVerifyEmail } from './get-verify-email';
+import { postSignup } from './post-signup';
 import { putRecordDetail } from './put-record-detail';
 
 export const handlers = [
@@ -16,4 +18,6 @@ export const handlers = [
   ...putRecordDetail,
   ...deleteRecordDetail,
   ...createRecordDetail,
+  ...postSignup,
+  ...getVerifyEmail,
 ];

--- a/src/mocks/handlers/post-signup.ts
+++ b/src/mocks/handlers/post-signup.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw';
 import type { SignupTypes } from '@/types/api/auth';
 
 export const postSignup = [
-  http.post('api/v1/auth/signup', async ({ request }) => {
+  http.post('/api/v1/auth/signup', async ({ request }) => {
     const { email, password } = (await request.json()) as SignupTypes;
 
     if (email === 'test@naver.com' && password === 'ab12345678') {

--- a/src/mocks/handlers/post-signup.ts
+++ b/src/mocks/handlers/post-signup.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from 'msw';
+
+import type { SignupTypes } from '@/types/api/auth';
+
+export const postSignup = [
+  http.post('api/v1/auth/signup', async ({ request }) => {
+    const { email, password } = (await request.json()) as SignupTypes;
+
+    if (email === 'test@naver.com' && password === 'ab12345678') {
+      return HttpResponse.json(
+        {
+          status: 401,
+          code: 'EDMT-40001',
+          message: '중복된 이메일입니다.',
+        },
+        { status: 401 },
+      );
+    }
+
+    return HttpResponse.json({
+      status: 200,
+      code: 'EDMT-20002',
+      message: '요청에 성공했습니다.',
+    });
+  }),
+];

--- a/src/services/auth/get-verify-email.ts
+++ b/src/services/auth/get-verify-email.ts
@@ -1,5 +1,6 @@
-export const getVerifyEmail = async (email: string, token: string) => {
-  console.log(email, token);
+import type { Response } from '@/types/api/response';
+
+export const getVerifyEmail = async (email: string, token: string): Promise<Response<null>> => {
   const res = await fetch(
     `/api/v1/auth/verify-email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`,
   );
@@ -9,5 +10,6 @@ export const getVerifyEmail = async (email: string, token: string) => {
     throw new Error(error.message || '이메일 인증에 실패했습니다.');
   }
 
-  return res.json();
+  const json: Response<null> = await res.json();
+  return json;
 };

--- a/src/services/auth/get-verify-email.ts
+++ b/src/services/auth/get-verify-email.ts
@@ -1,0 +1,13 @@
+export const getVerifyEmail = async (email: string, token: string) => {
+  console.log(email, token);
+  const res = await fetch(
+    `/api/v1/auth/verify-email?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`,
+  );
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || '이메일 인증에 실패했습니다.');
+  }
+
+  return res.json();
+};

--- a/src/services/auth/signup.ts
+++ b/src/services/auth/signup.ts
@@ -1,0 +1,25 @@
+import type { SignupTypes } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const signup = async ({
+  email,
+  password,
+  subject,
+  school,
+}: SignupTypes): Promise<Response<null>> => {
+  const res = await fetch('/api/v1/auth/signup', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password, subject, school }),
+  });
+
+  const json: Response<null> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '회원가입 실패');
+  }
+
+  return json;
+};

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,4 +1,4 @@
-export type SchoolType = '“middleSchool' | 'highSchool';
+export type SchoolType = 'middle' | 'high';
 
 export type AccessTokenType = {
   id: string;
@@ -15,4 +15,11 @@ export type LoginResponse = {
 export type LoginProp = {
   email: string;
   password: string;
+};
+
+export type SignupTypes = {
+  email: string;
+  password: string;
+  subject: string;
+  school: string;
 };


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-149]

## 🌱 주요 변경 사항

1. 회원가입 mock api 구현
2. 이메일 인증 확인 mock api 구현
3. 회원가입 api 로직 구현
4. 이메일 인증 확인 api 로직 구현
5. 이메일 인증 확인 페이지 구현
6. 회원가입 api 로직 연동

## 추후 고려해야 될 사항
1. email 인증 페이지에서 실제 api 연동할 때 원하는대로 동작하는지 확인해야함 (현재 msw코드로는 확인 불가능)
2. email 인증 페이지에서 github push를 위해 suspense 코드를 추가했는데, 왜 해주어야 하는지에 대한 이유를 찾아봐야함


[EDMT-149]: https://bbangbbangz.atlassian.net/browse/EDMT-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added email verification page with loading feedback and status messages.
  - Implemented user signup functionality with form validation, submission handling, and error feedback.
- **Bug Fixes**
  - Corrected type definitions for school selection in signup.
- **Chores**
  - Introduced mock API handlers for signup and email verification to support development and testing.
- **Refactor**
  - Standardized component and schema naming for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->