### PR TITLE
[EDMT-185] 이메일 인증 안되었을 때 error handling 로직 추가 및 이메일 인증 ui, modal 구현

### DIFF
--- a/src/components/modal/email-sent-modal.tsx
+++ b/src/components/modal/email-sent-modal.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Mail } from 'lucide-react';
+
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalOverlay,
+  ModalPortal,
+} from './base-modal';
+
+interface EmailSentModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function EmailSentModal({ open, onOpenChange }: EmailSentModalProps) {
+  const handleConfirm = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalPortal>
+        <ModalOverlay />
+        <ModalContent aria-describedby={undefined} className="max-w-md rounded-xl px-8 py-6">
+          <ModalHeader className="w-full">
+            <ModalTitle className="flex flex-col items-center justify-center gap-4 text-[20px]">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+                <Mail className="h-8 w-8 text-green-600" />
+              </div>
+              <span className="text-gray-800">이메일이 발송되었습니다</span>
+            </ModalTitle>
+          </ModalHeader>
+
+          <div className="mt-6 flex justify-center">
+            <button
+              onClick={handleConfirm}
+              className="rounded-md bg-slate-800 px-6 py-2 font-bold text-white transition-colors hover:bg-slate-950"
+            >
+              확인
+            </button>
+          </div>
+        </ModalContent>
+      </ModalPortal>
+    </Modal>
+  );
+}

--- a/src/components/record/email-verification.tsx
+++ b/src/components/record/email-verification.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+
+import EmailSentModal from '@/components/modal/email-sent-modal';
+import { usePostSendEmail } from '@/hooks/api/use-post-send-email';
+
+export default function EmailVerification() {
+  const [open, setOpen] = useState(false);
+
+  const { mutate: postSendEmail, isPending } = usePostSendEmail();
+
+  const handleSendEmail = () => {
+    postSendEmail(undefined, {
+      onSuccess: () => {
+        setOpen(true);
+      },
+      onError: (error) => {
+        alert(error.message);
+      },
+    });
+  };
+
+  return (
+    <>
+      <p className="text-[20px] font-bold">이메일 인증 후 서비스 이용이 가능합니다.</p>
+      <button
+        onClick={handleSendEmail}
+        disabled={isPending}
+        className="rounded-lg bg-slate-800 px-10 py-4 text-[20px] font-bold text-white hover:bg-slate-950"
+      >
+        이메일 인증하기
+      </button>
+      <EmailSentModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/src/components/record/record-body.tsx
+++ b/src/components/record/record-body.tsx
@@ -7,13 +7,15 @@ import Link from 'next/link';
 import { useGetRecords } from '@/hooks/api/use-get-records';
 import type { RecordType } from '@/types/api/student-record';
 
+import EmailVerification from './email-verification';
 import EmptyRecord from './empty-record';
 import RecordDetailAdd from './record-detail-add';
 import RecordDetailEdit from './record-detail-edit';
 import RecordDetailView from './record-detail-view';
 
 export default function RecordBody({ recordType }: { recordType: RecordType }) {
-  const { data, isPending, isError, isUnauthorized, isNotFound } = useGetRecords(recordType);
+  const { data, isPending, isError, isUnauthorized, isNotFound, isNotPermission } =
+    useGetRecords(recordType);
   const [editingId, setEditingId] = useState<string | null>(null);
 
   const renderTableRow = (content: React.ReactNode) => (
@@ -39,6 +41,8 @@ export default function RecordBody({ recordType }: { recordType: RecordType }) {
         </Link>
       </>
     );
+  } else if (isNotPermission) {
+    content = <EmailVerification />;
   } else if (isNotFound) {
     content = <EmptyRecord recordType={recordType} />;
   } else if (isError || !data) {

--- a/src/hooks/api/use-get-records.ts
+++ b/src/hooks/api/use-get-records.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { useAuth } from '@/contexts/auth/use-auth';
-import { isUnauthorizedError, isNotFoundError } from '@/lib/errors';
+import { isUnauthorizedError, isNotFoundError, isNotPermissionError } from '@/lib/errors';
 import { getRecords } from '@/services/student-manage/get-records';
 import type { RecordType, StudentsResponse } from '@/types/api/student-record';
 
@@ -18,5 +18,6 @@ export const useGetRecords = (recordType: RecordType) => {
     ...query,
     isUnauthorized: isUnauthorizedError(query.error),
     isNotFound: isNotFoundError(query.error),
+    isNotPermission: isNotPermissionError(query.error),
   };
 };

--- a/src/hooks/api/use-post-send-email.ts
+++ b/src/hooks/api/use-post-send-email.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useAuth } from '@/contexts/auth/use-auth';
+import { postSendEmail } from '@/services/auth/post-send-email';
+import type { Response } from '@/types/api/response';
+
+export const usePostSendEmail = () => {
+  const { accessToken } = useAuth();
+
+  return useMutation<Response<void>, Error, void>({
+    mutationFn: async () => {
+      if (!accessToken) {
+        throw new Error('로그인 상태가 아닙니다.');
+      }
+      return postSendEmail(accessToken);
+    },
+  });
+};

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -16,3 +16,7 @@ export const isUnauthorizedError = (error: unknown): boolean => {
 export const isNotFoundError = (error: unknown): boolean => {
   return error instanceof ApiError && error.code === 'EDMT-4040201';
 };
+
+export const isNotPermissionError = (error: unknown): boolean => {
+  return error instanceof ApiError && error.code === 'EDMT-4030101';
+};

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -13,6 +13,7 @@ import { patchReissue } from './patch-reissue';
 import { postLogin } from './post-login';
 import { postLogout } from './post-logout';
 import { postPrompt } from './post-prompt';
+import { postSendEmail } from './post-send-email';
 import { postSignup } from './post-signup';
 import { postSummaryRecordDetail } from './post-summary-record-detail';
 
@@ -34,4 +35,5 @@ export const handlers = [
   ...getProfile,
   ...postLogout,
   ...patchReissue,
+  ...postSendEmail,
 ];

--- a/src/mocks/handlers/post-send-email.ts
+++ b/src/mocks/handlers/post-send-email.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw';
+
+export const postSendEmail = [
+  http.post('/api/v1/auth/email/send-verification', async () => {
+    return HttpResponse.json(
+      { status: 200, code: 'EDMT-200', message: '요청이 성공했습니다.' },
+      { status: 200 },
+    );
+  }),
+];

--- a/src/services/auth/post-send-email.ts
+++ b/src/services/auth/post-send-email.ts
@@ -1,0 +1,22 @@
+import type { Response } from '@/types/api/response';
+
+export const postSendEmail = async (accessToken: string): Promise<Response<void>> => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/email/send-verification`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  const json: Response<void> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '이메일 전송 실패');
+  }
+
+  return json;
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-185]

## 🌱 주요 변경 사항

1. 이메일 인증 코드 보내는 fetch api 로직 구현 및 useMutation으로 추상화
2. 이메일 인증 코드 보내는 mock api 구현
3. 이메일 인증 안되어있을때의 error handling을 위한 error 상태 추가 및 record-body에 해당 로직 추가
4. 이메일 인증이 안되어있을 때 알려주는 ui 컴포넌트 구현 및 api 요청 성공했을 때 보여줄 확인 모달 구현

## 📸 스크린샷 (선택)

<img width="1709" alt="스크린샷 2025-06-22 오전 12 47 48" src="https://github.com/user-attachments/assets/42e01c1b-fb77-464a-b3f2-5629a8591bd5" />

<img width="1709" alt="스크린샷 2025-06-22 오전 12 47 58" src="https://github.com/user-attachments/assets/a506cb58-66d7-413b-90bf-36c6a0cf3794" />


[EDMT-185]: https://bbangbbangz.atlassian.net/browse/EDMT-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이메일 인증 요청 및 발송 기능이 추가되었습니다.
  - 이메일이 성공적으로 발송되었음을 안내하는 모달 창이 제공됩니다.
  - 권한이 없는 경우, 이메일 인증을 안내하는 화면이 표시됩니다.

- **버그 수정**
  - 권한 오류를 구분하여 보다 정확한 안내가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->