### PR TITLE
[EDMT-172] 생기부 작성 페이지에서 사용하는 모든 api 리팩토링 및 후처리 로직 적용

### DIFF
--- a/src/components/modal/save-summary-record-modal.tsx
+++ b/src/components/modal/save-summary-record-modal.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Save } from 'lucide-react';
+
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalOverlay,
+  ModalPortal,
+} from './base-modal';
+
+interface SaveSummaryRecordModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function SaveSummaryRecordModal({
+  open,
+  onOpenChange,
+}: SaveSummaryRecordModalProps) {
+  const handleConfirm = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalPortal>
+        <ModalOverlay />
+        <ModalContent aria-describedby={undefined} className="max-w-md rounded-xl px-8 py-6">
+          <ModalHeader className="w-full">
+            <ModalTitle className="flex flex-col items-center justify-center gap-4 text-[20px]">
+              <Save className="h-8 w-8" />
+              <span className="text-gray-800">성공적으로 저장되었습니다</span>
+            </ModalTitle>
+          </ModalHeader>
+
+          <div className="mt-6 flex justify-center">
+            <button
+              onClick={handleConfirm}
+              className="rounded-md bg-slate-800 px-6 py-2 font-bold text-white transition-colors hover:bg-slate-950"
+            >
+              확인
+            </button>
+          </div>
+        </ModalContent>
+      </ModalPortal>
+    </Modal>
+  );
+}

--- a/src/components/record/record-detail-edit.tsx
+++ b/src/components/record/record-detail-edit.tsx
@@ -1,6 +1,9 @@
-import { useRef } from 'react';
+'use client';
+
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { Input } from '@/components/input/input';
+import { Textarea } from '@/components/textarea/textarea';
 import { useDeleteRecordDetail } from '@/hooks/api/use-delete-record-detail';
 import { usePatchRecordDetail } from '@/hooks/api/use-patch-record-detail';
 import type {
@@ -18,17 +21,27 @@ interface RecordDetailEditProps {
 
 export default function RecordDetailEdit({ record, recordType, onView }: RecordDetailEditProps) {
   const { mutate: patchRecordDetail } = usePatchRecordDetail();
-
   const { mutate: deleteRecordDetail } = useDeleteRecordDetail();
 
   const studentNumberRef = useRef<HTMLInputElement>(null);
   const studentNameRef = useRef<HTMLInputElement>(null);
-  const descriptionRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const [textareaHeight, setTextareaHeight] = useState<number>(0);
+
+  const resizeTextarea = () => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+      setTextareaHeight(el.scrollHeight + 15);
+    }
+  };
 
   const handleSave = () => {
     const updatedStudentNumber = studentNumberRef.current?.value || '';
     const updatedName = studentNameRef.current?.value || '';
-    const updatedDescription = descriptionRef.current?.value || '';
+    const updatedDescription = textareaRef.current?.value || '';
     const updatedByteCount = calculateByte(updatedDescription);
 
     const updateStudentRecord: UpdateStudentRecordTypes = {
@@ -46,6 +59,10 @@ export default function RecordDetailEdit({ record, recordType, onView }: RecordD
     deleteRecordDetail({ recordType, recordId: record.recordDetailId });
   };
 
+  useLayoutEffect(() => {
+    resizeTextarea();
+  }, [record.description]);
+
   return (
     <tr className="relative">
       <td className="py-2 pl-5">
@@ -55,9 +72,24 @@ export default function RecordDetailEdit({ record, recordType, onView }: RecordD
         <Input defaultValue={record.studentName} ref={studentNameRef} className="w-full p-1" />
       </td>
       <td className="py-2 pl-5">
-        <Input defaultValue={record.description} ref={descriptionRef} className="w-full p-1" />
+        <Textarea
+          ref={textareaRef}
+          defaultValue={record.description}
+          className="min-h-0 w-full resize-none p-1 text-sm"
+          style={{
+            lineHeight: 'inherit',
+            fontSize: 'inherit',
+            overflow: 'hidden',
+          }}
+          onInput={resizeTextarea}
+        />
       </td>
-      <td className="absolute right-0 top-14 flex gap-2">
+      <td
+        className="absolute right-0 flex gap-2"
+        style={{
+          top: `${textareaHeight}px`,
+        }}
+      >
         <button
           className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
           onClick={onView}

--- a/src/components/record/record-detail-view.tsx
+++ b/src/components/record/record-detail-view.tsx
@@ -8,9 +8,9 @@ interface RecordDetailViewProps {
 export default function RecordDetailView({ record, onEdit }: RecordDetailViewProps) {
   return (
     <tr onClick={onEdit} className="h-12 cursor-pointer transition-colors hover:bg-slate-200">
-      <td className="pl-5">{record.studentNumber}</td>
-      <td className="pl-5">{record.studentName}</td>
-      <td className="pl-5">{record.description}</td>
+      <td className="py-3 pl-5">{record.studentNumber}</td>
+      <td className="py-3 pl-5">{record.studentName}</td>
+      <td className="py-3 pl-5">{record.description}</td>
     </tr>
   );
 }

--- a/src/components/student-record-write/ai-response.tsx
+++ b/src/components/student-record-write/ai-response.tsx
@@ -1,17 +1,68 @@
-const responses = [1, 2, 3];
+import type { AiResponseData } from '@/types/api/student-record';
+import { calculateByte } from '@/util/calculate-byte';
 
-export default function AiResponse({ selectedId }: { selectedId: number }) {
+interface AiResponseProps {
+  selectedId: number;
+  responses: AiResponseData | null;
+  isGenerating: boolean;
+}
+
+export default function AiResponse({ responses, isGenerating }: AiResponseProps) {
+  const getContentForVersion = (version: number) => {
+    if (isGenerating) {
+      return '생성 중입니다...';
+    }
+
+    if (!responses) {
+      return '프롬프트를 입력하고 생성 버튼을 눌러주세요.';
+    }
+
+    const descriptions = [responses.description1, responses.description2, responses.description3];
+    return descriptions[version - 1] || '';
+  };
+
+  const getTextColor = () => {
+    if (responses && !isGenerating) {
+      return 'text-slate-700';
+    }
+    return 'text-slate-400';
+  };
+
+  const getTextLength = (version: number) => {
+    if (!responses) return 0;
+    if (isGenerating) {
+      return 0;
+    }
+
+    const descriptions = [responses.description1, responses.description2, responses.description3];
+    return calculateByte(descriptions[version - 1]) || 0;
+  };
+
   return (
     <div className="flex flex-col gap-10">
-      {responses.map((version) => (
-        <div key={version} className="relative">
-          <h4 className="mb-2 font-bold">(버전 {version})</h4>
-          <div className="min-h-40 rounded-lg border border-slate-400 p-5">
-            <p className="text-slate-400">(이곳에 결과물 표시)</p>
-          </div>
-          <span className="absolute bottom-1 right-2 text-slate-400">1000/1500</span>
+      <div className="relative">
+        <h4 className="mb-2 font-bold">(버전 1)</h4>
+        <div className="min-h-40 rounded-lg border border-slate-400 p-5">
+          <p className={`whitespace-pre-wrap ${getTextColor()}`}>{getContentForVersion(1)}</p>
         </div>
-      ))}
+        <span className="absolute bottom-1 right-2 text-slate-400">{getTextLength(1)}/1500</span>
+      </div>
+
+      <div className="relative">
+        <h4 className="mb-2 font-bold">(버전 2)</h4>
+        <div className="min-h-40 rounded-lg border border-slate-400 p-5">
+          <p className={`whitespace-pre-wrap ${getTextColor()}`}>{getContentForVersion(2)}</p>
+        </div>
+        <span className="absolute bottom-1 right-2 text-slate-400">{getTextLength(2)}/1500</span>
+      </div>
+
+      <div className="relative">
+        <h4 className="mb-2 font-bold">(버전 3)</h4>
+        <div className="min-h-40 rounded-lg border border-slate-400 p-5">
+          <p className={`whitespace-pre-wrap ${getTextColor()}`}>{getContentForVersion(3)}</p>
+        </div>
+        <span className="absolute bottom-1 right-2 text-slate-400">{getTextLength(3)}/1500</span>
+      </div>
     </div>
   );
 }

--- a/src/components/student-record-write/record-summary.tsx
+++ b/src/components/student-record-write/record-summary.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
 
+import SaveSummaryRecordModal from '@/components/modal/save-summary-record-modal';
 import { Textarea } from '@/components/textarea/textarea';
 import { useGetSummaryRecordDetail } from '@/hooks/api/use-get-summary-record-detail';
 import { usePostSummaryRecordDetail } from '@/hooks/api/use-post-summary-record-detail';
 import { calculateByte } from '@/util/calculate-byte';
 
 export default function RecordSummary({ selectedId }: { selectedId: number }) {
+  const [modalOpen, setModalOpen] = useState(false);
   const [description, setDescription] = useState('');
   const { mutate: postSummaryRecordDetail } = usePostSummaryRecordDetail();
   const { data, isPending, isError } = useGetSummaryRecordDetail(selectedId);
@@ -19,11 +21,21 @@ export default function RecordSummary({ selectedId }: { selectedId: number }) {
   const handleSave = () => {
     const byteCount = calculateByte(description);
 
-    postSummaryRecordDetail({
-      recordId: selectedId,
-      description,
-      byteCount,
-    });
+    postSummaryRecordDetail(
+      {
+        recordId: selectedId,
+        description,
+        byteCount,
+      },
+      {
+        onSuccess: () => {
+          setModalOpen(true);
+        },
+        onError: (error) => {
+          alert(error.message);
+        },
+      },
+    );
   };
 
   if (isError) {
@@ -56,6 +68,7 @@ export default function RecordSummary({ selectedId }: { selectedId: number }) {
         </button>
       </div>
       <span className="absolute bottom-14 right-2 text-slate-400">{`${calculateByte(description)}/1500`}</span>
+      <SaveSummaryRecordModal open={modalOpen} onOpenChange={setModalOpen} />
     </div>
   );
 }

--- a/src/hooks/api/use-get-students-name.ts
+++ b/src/hooks/api/use-get-students-name.ts
@@ -1,11 +1,26 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { useAuth } from '@/contexts/auth/use-auth';
+import { isUnauthorizedError, isNotFoundError } from '@/lib/errors';
 import { getStudentsName } from '@/services/write-record/get-students-name';
 import type { RecordType, StudentNameTypes } from '@/types/api/student-record';
 
 export const useGetStudentsName = (recordType: RecordType, semester: string) => {
-  return useQuery<StudentNameTypes[]>({
+  const { accessToken } = useAuth();
+
+  const query = useQuery<StudentNameTypes[]>({
     queryKey: ['studentsName', recordType, semester],
-    queryFn: () => getStudentsName(recordType, semester),
+    queryFn: () => getStudentsName(recordType, semester, accessToken),
+    retry: 1,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
   });
+
+  return {
+    ...query,
+    isUnauthorized: isUnauthorizedError(query.error),
+    isNotFound: isNotFoundError(query.error),
+  };
 };

--- a/src/hooks/api/use-get-summary-record-detail.ts
+++ b/src/hooks/api/use-get-summary-record-detail.ts
@@ -1,11 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { useAuth } from '@/contexts/auth/use-auth';
 import { getSummaryRecordDetail } from '@/services/write-record/get-summary-record-detail';
 import type { SummaryRecordTypes } from '@/types/api/student-record';
 
 export const useGetSummaryRecordDetail = (recordId: number) => {
+  const { accessToken } = useAuth();
+
   return useQuery<SummaryRecordTypes>({
     queryKey: ['summary-record-detail', recordId],
-    queryFn: () => getSummaryRecordDetail(recordId),
+    queryFn: () => getSummaryRecordDetail(recordId, accessToken),
+    enabled: !!recordId && recordId > 0 && !isNaN(recordId) && !!accessToken,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
   });
 };

--- a/src/hooks/api/use-post-prompt.ts
+++ b/src/hooks/api/use-post-prompt.ts
@@ -1,10 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 
+import { useAuth } from '@/contexts/auth/use-auth';
 import { postPrompt } from '@/services/write-record/post-prompt';
+import type { PostPrompt, AiResponseData } from '@/types/api/student-record';
 
 export const usePostPrompt = () => {
-  return useMutation({
-    mutationFn: postPrompt,
+  const { accessToken } = useAuth();
+
+  return useMutation<AiResponseData, Error, PostPrompt>({
+    mutationFn: (params) => postPrompt({ ...params, accessToken }),
     onSuccess: (data) => {
       console.log('프롬프팅 텍스트 전송 성공:', data);
     },

--- a/src/hooks/api/use-post-summary-record-detail.ts
+++ b/src/hooks/api/use-post-summary-record-detail.ts
@@ -1,15 +1,28 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { useAuth } from '@/contexts/auth/use-auth';
 import { postSummaryRecordDetail } from '@/services/write-record/post-summary-record-detail';
+import type { Response } from '@/types/api/response';
+
+interface PostSummaryParams {
+  recordId: number;
+  description: string;
+  byteCount: number;
+}
 
 export const usePostSummaryRecordDetail = () => {
-  return useMutation({
-    mutationFn: postSummaryRecordDetail,
-    onSuccess: (data) => {
-      console.log('생기부 데이터 생성 성공:', data);
+  const { accessToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation<Response<null>, Error, PostSummaryParams>({
+    mutationFn: (params) => postSummaryRecordDetail({ ...params, accessToken }),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['summary-record-detail', variables.recordId],
+      });
     },
     onError: (error) => {
-      console.error('생기부 데이터 생성 실패:', error.message);
+      alert(error.message);
     },
   });
 };

--- a/src/services/write-record/get-students-name.ts
+++ b/src/services/write-record/get-students-name.ts
@@ -1,18 +1,26 @@
+import { ApiError } from '@/lib/errors';
 import type { Response } from '@/types/api/response';
 import type { RecordType, StudentNameTypes } from '@/types/api/student-record';
 
 export const getStudentsName = async (
   recordType: RecordType,
   semester: string,
+  accessToken: string | null,
 ): Promise<StudentNameTypes[]> => {
-  const res = await fetch(`/api/v1/student-records/${recordType}/students?semester=${semester}`);
-
-  if (!res.ok) {
-    const error = await res.json();
-    throw new Error(error.message || '데이터 fetch 실패');
-  }
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/student-records/${recordType}/students?semester=${semester}`,
+    {
+      headers: {
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+    },
+  );
 
   const json: Response<{ studentDetails: StudentNameTypes[] }> = await res.json();
+
+  if (!res.ok) {
+    throw new ApiError(json.status, json.code, json.message || '데이터 fetch 실패');
+  }
 
   return json.data?.studentDetails ?? [];
 };

--- a/src/services/write-record/get-summary-record-detail.ts
+++ b/src/services/write-record/get-summary-record-detail.ts
@@ -1,13 +1,23 @@
 import type { Response } from '@/types/api/response';
 import type { SummaryRecordTypes } from '@/types/api/student-record';
 
-export const getSummaryRecordDetail = async (recordId: number): Promise<SummaryRecordTypes> => {
-  const res = await fetch(`/api/v1/student-records/detail/${recordId}`);
+export const getSummaryRecordDetail = async (
+  recordId: number,
+  accessToken: string | null,
+): Promise<SummaryRecordTypes> => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/student-records/detail/${recordId}`,
+    {
+      headers: {
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+    },
+  );
 
   const json: Response<SummaryRecordTypes> = await res.json();
 
   if (!res.ok) {
-    throw new Error(json.message || '생기부 종합 작성 실패');
+    throw new Error(json.message || '생기부 종합 불러오기 실패');
   }
   if (!json.data) {
     throw new Error('응답에 데이터가 없습니다.');

--- a/src/services/write-record/post-prompt.ts
+++ b/src/services/write-record/post-prompt.ts
@@ -1,27 +1,38 @@
 import type { Response } from '@/types/api/response';
+import type { AiResponseData } from '@/types/api/student-record';
 
 interface PostPromptParams {
   recordId: number;
-  description: string;
+  prompt: string;
+  accessToken: string | null;
 }
 
 export const postPrompt = async ({
   recordId,
-  description,
-}: PostPromptParams): Promise<Response<null>> => {
-  const res = await fetch(`/api/v1/student-records/prompt/${recordId}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+  prompt,
+  accessToken,
+}: PostPromptParams): Promise<AiResponseData> => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/student-records/ai-generate/${recordId}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      body: JSON.stringify({ prompt }),
     },
-    body: JSON.stringify({ description }),
-  });
+  );
 
-  const json: Response<null> = await res.json();
+  const json: Response<AiResponseData> = await res.json();
 
   if (!res.ok) {
     throw new Error(json.message || '생기부 프롬프팅 전송 실패');
   }
 
-  return json;
+  if (!json.data) {
+    throw new Error('응답 데이터가 없습니다.');
+  }
+
+  return json.data;
 };

--- a/src/services/write-record/post-summary-record-detail.ts
+++ b/src/services/write-record/post-summary-record-detail.ts
@@ -3,20 +3,26 @@ import type { SummaryRecordTypes } from '@/types/api/student-record';
 
 interface PostSummaryRecordDetailParams extends SummaryRecordTypes {
   recordId: number;
+  accessToken: string | null;
 }
 
 export const postSummaryRecordDetail = async ({
   recordId,
   description,
   byteCount,
+  accessToken,
 }: PostSummaryRecordDetailParams): Promise<Response<null>> => {
-  const res = await fetch(`/api/v1/student-records/detail/${recordId}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/student-records/detail/${recordId}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      body: JSON.stringify({ description, byteCount }),
     },
-    body: JSON.stringify({ description, byteCount }),
-  });
+  );
 
   const json: Response<null> = await res.json();
 

--- a/src/types/api/student-record.ts
+++ b/src/types/api/student-record.ts
@@ -70,3 +70,14 @@ export type DeleteRecordDetailTypes = {
   recordId: string;
   accessToken: string | null;
 };
+
+export type PostPrompt = {
+  recordId: number;
+  prompt: string;
+};
+
+export interface AiResponseData {
+  description1: string;
+  description2: string;
+  description3: string;
+}


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-172]

## 🌱 주요 변경 사항

1. 나의 학생 관리 페이지에서 description에 컴포넌트 Input 태그에서 Textarea로 수정 및 그에 따른 높이 지정, useLayoutEffect를 활용해서 깜박임 현상 제거
2. prompt 요청/응답 type 추가
3. 종합 생기부 가져오는 api 리팩토링 및 invalidQuery 적용
4. 종합 생기부 저장하는 api 리팩토링 및 invalidQuery 적용, 저장 버튼 누를때 저장되었다고 알려주는 modal 구현 및 적용
5. 학생 이름 가져오는 api 리팩토링 및 invalidQuery 적용
6. prompt 요청하는 api 리팩토링 및 생성 전/ 생성 중/ 생성 후 상태에 따른 텍스트, 텍스트 색깔, byte 수 계산하는 함수 구현 및 적용

## 📸 스크린샷 (선택)
<img width="1710" alt="스크린샷 2025-06-23 오전 1 26 55" src="https://github.com/user-attachments/assets/8379440a-fa6e-42d7-97aa-31da08b25cd6" />
<img width="1710" alt="스크린샷 2025-06-23 오전 1 27 10" src="https://github.com/user-attachments/assets/7a056005-2b02-4096-817f-a361f1d75ada" />
<img width="1710" alt="스크린샷 2025-06-23 오전 1 27 28" src="https://github.com/user-attachments/assets/e57d7628-5535-49a7-83ea-a2d854532b57" />
<img width="1710" alt="스크린샷 2025-06-23 오전 1 27 39" src="https://github.com/user-attachments/assets/cdfd6d0d-bcb9-4915-b511-9ddeac0792e8" />




[EDMT-172]: https://bbangbbangz.atlassian.net/browse/EDMT-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - AI가 생성한 학생 기록 요약을 3가지 버전으로 확인할 수 있는 기능이 추가되었습니다.
  - 기록 저장 성공 시 안내 모달이 표시됩니다.

- **개선사항**
  - 학생 선택 및 AI 생성 입력란의 시각적 스타일이 개선되었습니다.
  - 기록 설명 입력란이 자동으로 높이가 조절되는 다중 줄 입력란으로 변경되었습니다.
  - 저장 및 에러 발생 시 사용자에게 명확한 피드백이 제공됩니다.
  - 인증 상태 및 데이터 미존재 시 안내 메시지가 표시됩니다.

- **버그 수정**
  - 테이블 셀의 패딩이 조정되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->