### PR TITLE
[EDMT-182] 회원가입 후 이메일 인증 완료되면 자동으로 브라우저 닫고, 회원가입 페이지로 돌아가면 랜딩페이지로 이동시키는 기능 추가

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  const isLogin = request.cookies.get('isLogin')?.value;
+  const isLogin = request.cookies.get('refreshToken')?.value;
   const { pathname } = request.nextUrl;
 
   const authPages = ['/login', '/signup', '/verify-email'];

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -1,4 +1,4 @@
-import { getVerifyEmail } from '@/services/auth/get-verify-email';
+import VerifyEmail from '@/components/verify-email/verify-email';
 
 interface PageProps {
   searchParams: {
@@ -7,34 +7,6 @@ interface PageProps {
   };
 }
 
-export default async function VerifyEmailPage({ searchParams }: PageProps) {
-  const id = searchParams?.id;
-  const code = searchParams?.code;
-
-  let isSuccess = false;
-
-  if (id && code) {
-    try {
-      await getVerifyEmail(id, code);
-      isSuccess = true;
-    } catch (e) {
-      isSuccess = false;
-    }
-  }
-
-  return (
-    <div className="flex min-h-screen w-full flex-col items-center justify-center px-4 text-center">
-      {isSuccess ? (
-        <>
-          <h1 className="text-2xl font-bold text-green-700">이메일 인증이 완료되었습니다!</h1>
-          <p className="mt-2 text-gray-600">원래 있던 브라우저로 돌아가주세요.</p>
-        </>
-      ) : (
-        <>
-          <h1 className="text-2xl font-bold text-red-700">이메일 인증에 실패했습니다.</h1>
-          <p className="mt-2 text-gray-600">이미 만료된 인증 코드입니다.</p>
-        </>
-      )}
-    </div>
-  );
+export default function Page({ searchParams }: PageProps) {
+  return <VerifyEmail searchParams={searchParams} />;
 }

--- a/src/app/(record)/page.tsx
+++ b/src/app/(record)/page.tsx
@@ -5,7 +5,7 @@ import landingPageImage from '../../../public/images/landing-page-image.png';
 
 export default function Page() {
   return (
-    <article className="mt-10 flex h-screen w-full flex-col items-center gap-8">
+    <article className="flex flex-col items-center gap-8">
       <Image src={landingPageImage} alt="랜딩 페이지 이미지" width={1000} />
       <div className="flex max-w-[1000px] gap-4">
         <Link

--- a/src/components/header/profile-dropdown.tsx
+++ b/src/components/header/profile-dropdown.tsx
@@ -23,9 +23,6 @@ export function ProfileDropDown({ onClose }: ProfileDropDownProps) {
   const { data, isPending, isError } = useGetProfile();
   const { mutate: handleLogout } = useLogout();
 
-  if (isPending) {
-    return <Loading />;
-  }
   if (isError) {
     return <DefaultError />;
   }
@@ -35,38 +32,49 @@ export function ProfileDropDown({ onClose }: ProfileDropDownProps) {
   const { nickname, isTeacherVerified, school } = data;
 
   return (
-    <div className="absolute right-0 top-[50px] z-10 flex w-[300px] flex-col gap-4 rounded-lg border bg-white p-4 shadow-lg">
-      <div className="flex gap-4">
-        <Link href={'/mypage'} onClick={() => onClose()}>
-          <Image src={ProfileImage} alt={`${nickname}의 프로필 이미지`} width={60} height={60} />
-        </Link>
-        <div className="flex flex-col justify-center">
-          <Link href={'/mypage'} onClick={() => onClose()}>
-            <div className="flex items-center gap-1 font-bold">
-              <Home size={20} />
-              <span className="pt-[2px] text-[20px]">{nickname}</span>
-              <span className="pt-[2px] text-[24px]">{'>'}</span>
-            </div>
-          </Link>
-          {isTeacherVerified ? (
-            <span className="text-sm text-gray-600">{SCHOOL_LABELS[school]} 교사</span>
-          ) : (
+    <div className="absolute right-0 top-[50px] z-10 flex h-[148px] w-[300px] flex-col gap-4 rounded-lg border bg-white p-4 shadow-lg">
+      {isPending ? (
+        <Loading />
+      ) : (
+        <>
+          <div className="flex gap-4">
             <Link href={'/mypage'} onClick={() => onClose()}>
-              <span className="text-sm text-red-500 hover:underline">교사 인증 필요</span>
+              <Image
+                src={ProfileImage}
+                alt={`${nickname}의 프로필 이미지`}
+                width={60}
+                height={60}
+              />
             </Link>
-          )}
-        </div>
-      </div>
-      <div className="flex w-full justify-between">
-        <div className="rounded-sm bg-slate-100 px-10 py-2 text-sm">2025-1학기</div>
-        <button
-          type="button"
-          className="rounded-sm bg-slate-100 px-8 py-2 text-sm hover:bg-slate-200"
-          onClick={() => handleLogout()}
-        >
-          로그아웃
-        </button>
-      </div>
+            <div className="flex flex-col justify-center">
+              <Link href={'/mypage'} onClick={() => onClose()}>
+                <div className="flex items-center gap-1 font-bold">
+                  <Home size={20} />
+                  <span className="pt-[2px] text-[20px]">{nickname}</span>
+                  <span className="pt-[2px] text-[24px]">{'>'}</span>
+                </div>
+              </Link>
+              {isTeacherVerified ? (
+                <span className="text-sm text-gray-600">{SCHOOL_LABELS[school]} 교사</span>
+              ) : (
+                <Link href={'/mypage'} onClick={() => onClose()}>
+                  <span className="text-sm text-red-500 hover:underline">교사 인증 필요</span>
+                </Link>
+              )}
+            </div>
+          </div>
+          <div className="flex w-full justify-between">
+            <div className="rounded-sm bg-slate-100 px-10 py-2 text-sm">2025-1학기</div>
+            <button
+              type="button"
+              className="rounded-sm bg-slate-100 px-8 py-2 text-sm hover:bg-slate-200"
+              onClick={() => handleLogout()}
+            >
+              로그아웃
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/signup/signup.tsx
+++ b/src/components/signup/signup.tsx
@@ -5,13 +5,12 @@ import { useState, useRef, useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 
-import Link from 'next/link';
-
 import { Input } from '@/components/input/input';
 import { subjects } from '@/constants/signup-data';
 import { useSignup } from '@/hooks/api/use-signup';
 
 import { signupSchema } from './signup-scheme';
+import SuccessSignup from './success-signup';
 
 import type { SignupDataType } from './signup-scheme';
 
@@ -110,22 +109,7 @@ export default function Signup() {
   }, [selectedIndex]);
 
   if (isSuccess) {
-    return (
-      <div className="flex flex-col items-center gap-10 py-8 text-center">
-        <h2 className="text-4xl font-bold">가입 완료</h2>
-        <p className="text-2xl text-gray-700">
-          가입하신 이메일로 인증 메일을 보냈습니다.
-          <br />
-          메일함을 확인해주세요.
-        </p>
-        <Link
-          href="/"
-          className="rounded-md bg-slate-800 px-6 py-3 text-2xl text-white hover:bg-slate-950"
-        >
-          서비스로 돌아가기
-        </Link>
-      </div>
-    );
+    return <SuccessSignup />;
   }
 
   return (

--- a/src/components/signup/success-signup.tsx
+++ b/src/components/signup/success-signup.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import EmailSentModal from '@/components/modal/email-sent-modal';
+import { usePostSendEmail } from '@/hooks/api/use-post-send-email';
+
+export default function SuccessSignup() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const { mutate: postSendEmail } = usePostSendEmail();
+
+  const handleClick = () => {
+    postSendEmail(undefined, {
+      onSuccess: () => {
+        setOpen(true);
+      },
+      onError: (error) => {
+        alert(error.message);
+      },
+    });
+  };
+
+  useEffect(() => {
+    const checkEmailVeification = () => {
+      const isVerified = localStorage.getItem('emailVerified');
+      const verifiedAt = localStorage.getItem('emailVerifiedAt');
+
+      if (isVerified === 'true' && verifiedAt) {
+        const verifiedTime = parseInt(verifiedAt);
+        const now = Date.now();
+
+        if (now - verifiedTime < 5 * 60 * 1000) {
+          setIsLoading(true);
+
+          localStorage.removeItem('emailVerified');
+          localStorage.removeItem('emailVerifiedAt');
+
+          setTimeout(() => {
+            router.push('/');
+          }, 1000);
+        }
+      }
+    };
+
+    const interval = setInterval(checkEmailVeification, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center gap-6 py-8 text-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-800" />
+        <p className="text-xl text-gray-700">인증이 완료되었습니다. 잠시만 기다려주세요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-10 py-8 text-center">
+      <h2 className="text-4xl font-bold">가입 완료</h2>
+      <p className="text-2xl text-gray-700">
+        가입하신 이메일로 인증 메일을 보냈습니다.
+        <br />
+        메일함을 확인해주세요.
+      </p>
+      <p className="cursor-pointer hover:underline" onClick={handleClick}>
+        이메일을 못받으셨나요?
+      </p>
+      <EmailSentModal open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/src/components/verify-email/verify-email-handler.tsx
+++ b/src/components/verify-email/verify-email-handler.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface VerifyEmailHandlerProps {
+  isSuccess: boolean;
+}
+
+export default function VerifyEmailHandler({ isSuccess }: VerifyEmailHandlerProps) {
+  useEffect(() => {
+    if (isSuccess) {
+      localStorage.setItem('emailVerified', 'true');
+      localStorage.setItem('emailVerifiedAt', Date.now().toString());
+
+      setTimeout(() => {
+        window.close();
+      }, 1000);
+    }
+  }, [isSuccess]);
+
+  return null;
+}

--- a/src/components/verify-email/verify-email.tsx
+++ b/src/components/verify-email/verify-email.tsx
@@ -1,0 +1,43 @@
+import { getVerifyEmail } from '@/services/auth/get-verify-email';
+
+import VerifyEmailHandler from './verify-email-handler';
+
+interface VerifyEmailProps {
+  searchParams: {
+    id?: string;
+    code?: string;
+  };
+}
+
+export default async function VerifyEmail({ searchParams }: VerifyEmailProps) {
+  const id = searchParams?.id;
+  const code = searchParams?.code;
+
+  let isSuccess = false;
+
+  if (id && code) {
+    try {
+      await getVerifyEmail(id, code);
+      isSuccess = true;
+    } catch {
+      isSuccess = false;
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center justify-center px-4 text-center">
+      {isSuccess ? (
+        <>
+          <h1 className="text-2xl font-bold text-green-700">이메일 인증이 완료되었습니다!</h1>
+          <p className="mt-2 text-gray-600">원래 있던 브라우저로 돌아가주세요.</p>
+        </>
+      ) : (
+        <>
+          <h1 className="text-2xl font-bold text-red-700">이메일 인증에 실패했습니다.</h1>
+          <p className="mt-2 text-gray-600">이미 만료된 인증 코드입니다.</p>
+        </>
+      )}
+      <VerifyEmailHandler isSuccess={isSuccess} />
+    </div>
+  );
+}

--- a/src/contexts/auth/auth-context.tsx
+++ b/src/contexts/auth/auth-context.tsx
@@ -3,6 +3,8 @@ import { createContext } from 'react';
 interface AuthContextProps {
   accessToken: string | null;
   setAccessToken: (token: string | null) => void;
+  isAdmin: boolean | null;
+  setIsAdmin: (isAdmin: boolean | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextProps | null>(null);

--- a/src/contexts/auth/auth-provider.tsx
+++ b/src/contexts/auth/auth-provider.tsx
@@ -9,6 +9,7 @@ import { AuthContext } from './auth-context';
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
 
   useEffect(() => {
     const initializeAuth = async () => {
@@ -17,6 +18,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
         if (res) {
           setAccessToken(res.accessToken);
+          setIsAdmin(res.isAdmin);
         }
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (e) {
@@ -28,6 +30,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ accessToken, setAccessToken }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ accessToken, setAccessToken, isAdmin, setIsAdmin }}>
+      {children}
+    </AuthContext.Provider>
   );
 };

--- a/src/hooks/api/use-login.ts
+++ b/src/hooks/api/use-login.ts
@@ -9,12 +9,13 @@ import type { LoginProp, AuthResponse } from '@/types/api/auth';
 export const useLogin = () => {
   const router = useRouter();
 
-  const { setAccessToken } = useAuth();
+  const { setAccessToken, setIsAdmin } = useAuth();
 
   return useMutation<AuthResponse, Error, LoginProp>({
     mutationFn: login,
     onSuccess: (data) => {
       setAccessToken(data.accessToken);
+      setIsAdmin(data.isAdmin);
       router.push('/');
     },
   });

--- a/src/hooks/api/use-signup.ts
+++ b/src/hooks/api/use-signup.ts
@@ -1,14 +1,17 @@
 import { useMutation } from '@tanstack/react-query';
 
+import { useAuth } from '@/contexts/auth/use-auth';
 import { signup } from '@/services/auth/signup';
-import type { SignupTypes } from '@/types/api/auth';
-import type { Response } from '@/types/api/response';
+import type { AuthResponse, SignupTypes } from '@/types/api/auth';
 
 export const useSignup = () => {
-  return useMutation<Response<null>, Error, SignupTypes>({
+  const { setAccessToken, setIsAdmin } = useAuth();
+
+  return useMutation<AuthResponse, Error, SignupTypes>({
     mutationFn: signup,
     onSuccess: (data) => {
-      console.log(data);
+      setAccessToken(data.accessToken);
+      setIsAdmin(data.isAdmin);
     },
     onError: (error) => {
       alert(error.message);

--- a/src/services/auth/signup.ts
+++ b/src/services/auth/signup.ts
@@ -1,4 +1,4 @@
-import type { SignupTypes } from '@/types/api/auth';
+import type { AuthResponse, SignupTypes } from '@/types/api/auth';
 import type { Response } from '@/types/api/response';
 
 export const signup = async ({
@@ -6,7 +6,7 @@ export const signup = async ({
   password,
   subject,
   school,
-}: SignupTypes): Promise<Response<null>> => {
+}: SignupTypes): Promise<AuthResponse> => {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/signup`, {
     method: 'POST',
     headers: {
@@ -15,11 +15,15 @@ export const signup = async ({
     body: JSON.stringify({ email, password, subject, school }),
   });
 
-  const json: Response<null> = await res.json();
+  const json: Response<AuthResponse> = await res.json();
 
   if (!res.ok) {
     throw new Error(json.message || '회원가입 실패');
   }
 
-  return json;
+  if (!json.data) {
+    throw new Error(json.message || '회원가입 실패');
+  }
+
+  return json.data;
 };

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -2,6 +2,7 @@ export type SchoolType = 'middle' | 'high';
 
 export type AuthResponse = {
   accessToken: string;
+  isAdmin: boolean;
 };
 
 export type LoginProp = {


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-182]

## 🌱 주요 변경 사항

1. 회원가입 후 이메일 인증 완료되면 자동으로 브라우저 닫고, 회원가입 페이지로 돌아가면 랜딩페이지로 이동시키는 기능 추가(isVerified 값 localStorage에서 관리)
2. 랜딩 페이지 style 오류 수정
3. 프로필 dropdown에서 loading 컴포넌트 외부에서 내부로 수정 및 스타일링 수정
4. authContext에 isAdmin 필드 추가
5. middleware코드 isLogin에서 refreshToken으로 수정

