### PR TITLE
[EDMT-214] amplitude 기초 세팅 및 ai 버튼 클릭, 생기부 종합 버튼 클릭 시 trackEvent 추가

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ export function middleware(request: NextRequest) {
   const isLogin = request.cookies.get('refreshToken')?.value;
   const { pathname } = request.nextUrl;
 
-  const authPages = ['/login', '/signup', '/verify-email'];
+  const authPages = ['/login', '/verify-email'];
 
   if (isLogin && authPages.includes(pathname)) {
     return NextResponse.redirect(new URL('/', request.url));
@@ -15,5 +15,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/login', '/signup', '/verify-email'],
+  matcher: ['/login', '/verify-email'],
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     ]
   },
   "dependencies": {
-    "next": "14.2.26",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "@amplitude/analytics-browser": "^2.17.12",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
@@ -32,7 +30,11 @@
     "clsx": "^2.1.1",
     "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.511.0",
+    "next": "14.2.26",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-hook-form": "^7.56.4",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@amplitude/analytics-browser':
+        specifier: ^2.17.12
+        version: 2.17.12
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.58.1(react@18.3.1))
@@ -41,6 +44,9 @@ importers:
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@18.3.1)
@@ -159,6 +165,33 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@amplitude/analytics-browser@2.17.12':
+    resolution: {integrity: sha512-oADGSPJWcfnNyBqN7qDgEOEVrLxSb9Qh4wINi7DsRS8Mj55Ukh9M1iqQoLXrCXK/lbV4QMhUWn1ZmBAMCKYZKQ==}
+
+  '@amplitude/analytics-client-common@2.3.26':
+    resolution: {integrity: sha512-YVMZkugw01fsok2i3x/HhAYG8t9kYxnmNDl6oKbvZkzCzfRUuOKa+f0OLUD2SRJRxTKRanAwHINZuDdk3cR7qQ==}
+
+  '@amplitude/analytics-connector@1.6.4':
+    resolution: {integrity: sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==}
+
+  '@amplitude/analytics-core@2.14.0':
+    resolution: {integrity: sha512-JmKzlZ5I4JAlWLx2kcCuxH4XNthyaIa+NDAOfpP2xbgZGFM9Gsd9TO/a+SMyGAEryaxb1b5tYdIkMFhjHPjuHA==}
+
+  '@amplitude/analytics-remote-config@0.4.1':
+    resolution: {integrity: sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==}
+
+  '@amplitude/analytics-types@2.9.2':
+    resolution: {integrity: sha512-juhTz396dDP/jLJYP9zDOEAZBtJM0JVvP8G10p1OxUDBVwVIprpQL598F9GRQwVFyqV4CEhDmNyAY0HqqU5bhA==}
+
+  '@amplitude/plugin-autocapture-browser@1.4.0':
+    resolution: {integrity: sha512-vvqfCflFS8vCkMAmMxUP59h/g4hImsYKUMqevmT1dGbM9bq7eccRTP8JsTpoTomG70VLCUfqitQTMfXuWf9GVQ==}
+
+  '@amplitude/plugin-network-capture-browser@1.2.0':
+    resolution: {integrity: sha512-exFqJ3MWCs1d00Zj+XfwP0eXD8R4jG8Zd+bp3pUguGOVa9+x4UTbYWul2S9lt40Arp33DFijobl+ocDSRBCIFg==}
+
+  '@amplitude/plugin-page-view-tracking-browser@2.3.32':
+    resolution: {integrity: sha512-Y+6OUv0De1hI4GSdxlWFSsTvjKGsfWM2AP2+elLsPQuZxgBUXjmfkPwRLh4TLMmtbQPfX38vbddBVYWPSStRFw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2396,6 +2429,10 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3127,6 +3164,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -3642,6 +3682,56 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@amplitude/analytics-browser@2.17.12':
+    dependencies:
+      '@amplitude/analytics-core': 2.14.0
+      '@amplitude/analytics-remote-config': 0.4.1
+      '@amplitude/plugin-autocapture-browser': 1.4.0
+      '@amplitude/plugin-network-capture-browser': 1.2.0
+      '@amplitude/plugin-page-view-tracking-browser': 2.3.32
+      tslib: 2.8.1
+
+  '@amplitude/analytics-client-common@2.3.26':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@amplitude/analytics-core': 2.14.0
+      '@amplitude/analytics-types': 2.9.2
+      tslib: 2.8.1
+
+  '@amplitude/analytics-connector@1.6.4': {}
+
+  '@amplitude/analytics-core@2.14.0':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      tslib: 2.8.1
+
+  '@amplitude/analytics-remote-config@0.4.1':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.3.26
+      '@amplitude/analytics-core': 2.14.0
+      '@amplitude/analytics-types': 2.9.2
+      tslib: 2.8.1
+
+  '@amplitude/analytics-types@2.9.2': {}
+
+  '@amplitude/plugin-autocapture-browser@1.4.0':
+    dependencies:
+      '@amplitude/analytics-core': 2.14.0
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-network-capture-browser@1.2.0':
+    dependencies:
+      '@amplitude/analytics-core': 2.14.0
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-page-view-tracking-browser@2.3.32':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.3.26
+      '@amplitude/analytics-types': 2.9.2
+      tslib: 2.8.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6143,6 +6233,8 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
+  jwt-decode@4.0.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6791,6 +6883,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import AnalyticsProvider from '@/components/analytics/analytics-provider';
 import { AuthProvider } from '@/contexts/auth/auth-provider';
 import { MSWProvider } from '@/lib/msw-provider';
 import QueryProvider from '@/lib/tanstack-query-provider';
@@ -15,7 +16,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="overflow-hidden">
         <MSWProvider>
           <QueryProvider>
-            <AuthProvider>{children}</AuthProvider>
+            <AuthProvider>
+              <AnalyticsProvider>{children}</AnalyticsProvider>
+            </AuthProvider>
           </QueryProvider>
         </MSWProvider>
       </body>

--- a/src/components/analytics/analytics-provider.tsx
+++ b/src/components/analytics/analytics-provider.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import { initAmplitude, trackEvent, setUserInfo } from '@/lib/amplitude/amplitude';
+import { getKoreaFormattedTimeStamp } from '@/util/get-korea-formatted-time-stamp';
+
+export default function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const startTimeRef = useRef<number>(0);
+
+  // 1. Amplitude 초기화 + 기본 정보 수집
+  useEffect(() => {
+    initAmplitude();
+
+    // 기기/브라우저 정보
+    const userAgent = navigator.userAgent;
+    const getBrowser = () => {
+      if (userAgent.includes('Chrome')) return 'Chrome';
+      if (userAgent.includes('Safari')) return 'Safari';
+      if (userAgent.includes('Firefox')) return 'Firefox';
+      return 'Other';
+    };
+
+    const getOS = () => {
+      if (userAgent.includes('Windows')) return 'Windows';
+      if (userAgent.includes('Mac')) return 'Mac';
+      if (userAgent.includes('Android')) return 'Android';
+      if (userAgent.includes('iPhone')) return 'iOS';
+      return 'Other';
+    };
+
+    const getDevice = () => {
+      return /Mobi|Android/i.test(userAgent) ? 'Mobile' : 'Desktop';
+    };
+
+    // 사용자 기본 정보 설정
+    setUserInfo({
+      browser: getBrowser(),
+      os: getOS(),
+      device: getDevice(),
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      language: navigator.language,
+    });
+
+    // 유입 경로 추적
+    trackEvent('Session Start', {
+      referrer: document.referrer || 'Direct',
+      landing_page: pathname,
+    });
+  }, [pathname]);
+
+  // 2. 페이지별 체류 시간 추적
+  useEffect(() => {
+    // 이전 페이지 체류 시간 기록
+    if (startTimeRef.current > 0) {
+      const duration = Date.now() - startTimeRef.current;
+      trackEvent('Page Exit', {
+        duration_seconds: Math.round(duration / 1000),
+      });
+    }
+
+    // 새 페이지 시작
+    startTimeRef.current = Date.now();
+    trackEvent('Page View', {
+      page: pathname,
+      timestamp: getKoreaFormattedTimeStamp(),
+    });
+
+    // 페이지 나갈 때 체류 시간 기록
+    return () => {
+      if (startTimeRef.current > 0) {
+        const duration = Date.now() - startTimeRef.current;
+        trackEvent('Page Exit', {
+          page: pathname,
+          duration_seconds: Math.round(duration / 1000),
+        });
+      }
+    };
+  }, [pathname]);
+
+  return <>{children}</>;
+}

--- a/src/components/analytics/analytics-provider.tsx
+++ b/src/components/analytics/analytics-provider.tsx
@@ -50,7 +50,8 @@ export default function AnalyticsProvider({ children }: { children: React.ReactN
       referrer: document.referrer || 'Direct',
       landing_page: pathname,
     });
-  }, [pathname]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // 2. 페이지별 체류 시간 추적
   useEffect(() => {

--- a/src/components/student-record-write/characteristic-input.tsx
+++ b/src/components/student-record-write/characteristic-input.tsx
@@ -4,11 +4,15 @@ import { useRouter } from 'next/navigation';
 
 import { Textarea } from '@/components/textarea/textarea';
 import { usePostPrompt } from '@/hooks/api/use-post-prompt';
-import type { StudentNameTypes, AiResponseData } from '@/types/api/student-record';
+import { trackEvent } from '@/lib/amplitude/amplitude';
+import type { StudentNameTypes, AiResponseData, RecordType } from '@/types/api/student-record';
+import { calculateByte } from '@/util/calculate-byte';
+import { getKoreaFormattedTimeStamp } from '@/util/get-korea-formatted-time-stamp';
 
 interface CharacteristicInputProps {
   students: StudentNameTypes[];
   selectedId: number;
+  recordType: RecordType;
   onGenerationStart: () => void;
   onResponseGenerated: (data: AiResponseData) => void;
 }
@@ -16,6 +20,7 @@ interface CharacteristicInputProps {
 export default function CharacteristicInput({
   students,
   selectedId,
+  recordType,
   onGenerationStart,
   onResponseGenerated,
 }: CharacteristicInputProps) {
@@ -35,6 +40,12 @@ export default function CharacteristicInput({
       alert('내용을 입력해주세요.');
       return;
     }
+
+    trackEvent('AI 기능 사용', {
+      recordType: recordType,
+      inputLength: calculateByte(value),
+      timestamp: getKoreaFormattedTimeStamp(),
+    });
 
     onGenerationStart();
     postPrompt(

--- a/src/components/student-record-write/record-summary.tsx
+++ b/src/components/student-record-write/record-summary.tsx
@@ -6,8 +6,10 @@ import SaveSummaryRecordModal from '@/components/modal/save-summary-record-modal
 import { Textarea } from '@/components/textarea/textarea';
 import { useGetSummaryRecordDetail } from '@/hooks/api/use-get-summary-record-detail';
 import { usePostSummaryRecordDetail } from '@/hooks/api/use-post-summary-record-detail';
+import { trackEvent } from '@/lib/amplitude/amplitude';
 import type { RecordType } from '@/types/api/student-record';
 import { calculateByte } from '@/util/calculate-byte';
+import { getKoreaFormattedTimeStamp } from '@/util/get-korea-formatted-time-stamp';
 
 interface RecordSummaryProps {
   selectedId: number;
@@ -15,7 +17,6 @@ interface RecordSummaryProps {
 }
 
 export default function RecordSummary({ selectedId, recordType }: RecordSummaryProps) {
-  console.log(recordType);
   const [modalOpen, setModalOpen] = useState(false);
   const [description, setDescription] = useState('');
   const { mutate: postSummaryRecordDetail } = usePostSummaryRecordDetail();
@@ -29,6 +30,11 @@ export default function RecordSummary({ selectedId, recordType }: RecordSummaryP
 
   const handleSave = () => {
     const byteCount = calculateByte(description);
+    trackEvent('생활기록부 문장 확정', {
+      recordType: recordType,
+      inputLength: byteCount,
+      timestamp: getKoreaFormattedTimeStamp(),
+    });
 
     postSummaryRecordDetail(
       {

--- a/src/components/student-record-write/student-record-write.tsx
+++ b/src/components/student-record-write/student-record-write.tsx
@@ -74,6 +74,7 @@ export default function StudentRecordWrite({ recordType, recordId }: StudentReco
       <CharacteristicInput
         students={data}
         selectedId={parsedRecordId}
+        recordType={recordType}
         onGenerationStart={handleGenerationStart}
         onResponseGenerated={handleAiResponseGenerated}
       />

--- a/src/contexts/auth/auth-provider.tsx
+++ b/src/contexts/auth/auth-provider.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { useState, useEffect } from 'react';
 
+import { setAmplitudeUserFromAccessToken } from '@/lib/amplitude/set-user';
 import { reissue } from '@/services/auth/reissue';
 
 import { AuthContext } from './auth-context';
@@ -16,12 +17,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       try {
         const res = await reissue();
 
-        if (res) {
+        if (res?.accessToken) {
           setAccessToken(res.accessToken);
           setIsAdmin(res.isAdmin);
+
+          setAmplitudeUserFromAccessToken({
+            accessToken: res.accessToken,
+            isAdmin: res.isAdmin,
+          });
         }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (e) {
+      } catch {
         setAccessToken(null);
       }
     };

--- a/src/hooks/api/use-login.ts
+++ b/src/hooks/api/use-login.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { useAuth } from '@/contexts/auth/use-auth';
+import { setAmplitudeUserFromAccessToken } from '@/lib/amplitude/set-user';
 import { login } from '@/services/auth/login';
 import type { LoginProp, AuthResponse } from '@/types/api/auth';
 
@@ -16,6 +17,12 @@ export const useLogin = () => {
     onSuccess: (data) => {
       setAccessToken(data.accessToken);
       setIsAdmin(data.isAdmin);
+
+      setAmplitudeUserFromAccessToken({
+        accessToken: data.accessToken,
+        isAdmin: data.isAdmin,
+      });
+
       router.push('/');
     },
   });

--- a/src/hooks/api/use-logout.ts
+++ b/src/hooks/api/use-logout.ts
@@ -1,3 +1,4 @@
+import { reset } from '@amplitude/analytics-browser';
 import { useMutation } from '@tanstack/react-query';
 
 import { useRouter } from 'next/navigation';
@@ -20,11 +21,13 @@ export const useLogout = () => {
     onSuccess: () => {
       setAccessToken(null);
       setIsAdmin(false);
+      reset();
       router.push('/');
     },
     onError: () => {
       setAccessToken(null);
       setIsAdmin(false);
+      reset();
       router.push('/');
     },
   });

--- a/src/hooks/api/use-signup.ts
+++ b/src/hooks/api/use-signup.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { useAuth } from '@/contexts/auth/use-auth';
+import { setAmplitudeUserFromAccessToken } from '@/lib/amplitude/set-user';
 import { signup } from '@/services/auth/signup';
 import type { AuthResponse, SignupTypes } from '@/types/api/auth';
 
@@ -9,10 +10,17 @@ export const useSignup = () => {
 
   return useMutation<AuthResponse, Error, SignupTypes>({
     mutationFn: signup,
+
     onSuccess: (data) => {
       setAccessToken(data.accessToken);
       setIsAdmin(data.isAdmin);
+
+      setAmplitudeUserFromAccessToken({
+        accessToken: data.accessToken,
+        isAdmin: data.isAdmin,
+      });
     },
+
     onError: (error) => {
       alert(error.message);
     },

--- a/src/lib/amplitude/amplitude.ts
+++ b/src/lib/amplitude/amplitude.ts
@@ -1,0 +1,27 @@
+import { init, track, identify, Identify } from '@amplitude/analytics-browser';
+
+let isInitialized = false;
+
+export const initAmplitude = () => {
+  if (isInitialized) return;
+
+  const apiKey = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
+  if (!apiKey) return;
+
+  init(apiKey);
+  isInitialized = true;
+};
+
+export const trackEvent = (eventName: string, properties?: object) => {
+  if (!isInitialized) return;
+  track(eventName, properties);
+};
+
+export const setUserInfo = (properties: object) => {
+  if (!isInitialized) return;
+  const identifyEvent = new Identify();
+  Object.entries(properties).forEach(([key, value]) => {
+    identifyEvent.set(key, value);
+  });
+  identify(identifyEvent);
+};

--- a/src/lib/amplitude/set-user.ts
+++ b/src/lib/amplitude/set-user.ts
@@ -1,0 +1,30 @@
+import { setUserId, identify, Identify } from '@amplitude/analytics-browser';
+import { jwtDecode } from 'jwt-decode';
+
+import { getKoreaFormattedTimeStamp } from '@/util/get-korea-formatted-time-stamp';
+
+interface UserInfo {
+  accessToken: string;
+  isAdmin?: boolean;
+}
+
+export const setAmplitudeUserFromAccessToken = (user: UserInfo) => {
+  try {
+    const decoded = jwtDecode<{ uuid: string }>(user.accessToken);
+    const uuid = decoded.uuid;
+
+    if (!uuid) return;
+
+    setUserId(uuid);
+
+    const identifyEvent = new Identify();
+    if (user.isAdmin !== undefined) {
+      identifyEvent.set('role', user.isAdmin ? 'admin' : 'user');
+    }
+    identifyEvent.set('login_time', getKoreaFormattedTimeStamp());
+
+    identify(identifyEvent);
+  } catch (e) {
+    console.error('Failed to decode accessToken for Amplitude:', e);
+  }
+};

--- a/src/util/get-korea-formatted-time-stamp.ts
+++ b/src/util/get-korea-formatted-time-stamp.ts
@@ -1,0 +1,15 @@
+export const getKoreaFormattedTimeStamp = (): string => {
+  const now = new Date();
+
+  const kstString = now.toLocaleString('en-US', { timeZone: 'Asia/Seoul' });
+  const kstDate = new Date(kstString);
+
+  const yyyy = kstDate.getFullYear();
+  const mm = String(kstDate.getMonth() + 1).padStart(2, '0');
+  const dd = String(kstDate.getDate()).padStart(2, '0');
+  const hh = String(kstDate.getHours()).padStart(2, '0');
+  const min = String(kstDate.getMinutes()).padStart(2, '0');
+  const ss = String(kstDate.getSeconds()).padStart(2, '0');
+
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss}`;
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-214]

## 🌱 주요 변경 사항
1. amplitude, jwt-decode 라이브러리 설치
2. amplitude 기초 설정을 위한 initAmplitude 구현
3. amplitude 유저 기반 트래킹을 위한 set-user 구현 및 analytics-provider 구현, RootLayout에서 감싸줌
4. 현재 시간을 기반으로 한국 시간 0000-00-00 00:00:00 으로 보여지게 포맷팅 하는 get-korea-formatted-time-stamp 함수 구현
5. ai 버튼 클릭 횟수를 수집하기 위해 ai버튼 클릭 이벤트에 trackEvent 코드 추가
6. 생기부 종합 작성 버튼 클릭 횟수를 수집하기 위한 생기부 작성 버튼 클릭 이벤트에 trackEvent 코드 추가
7. accessToken에서 파싱하는 uuid를 기반으로 로그인/회원가입/새로고침/로그아웃에 amplitude로 들어갈 user_id setting 코드 추가

## 📸 스크린샷 (선택)

<img width="1710" alt="스크린샷 2025-06-28 오후 11 40 47" src="https://github.com/user-attachments/assets/5719aad3-a052-434b-8df3-4e3e88bcd113" />



[EDMT-214]: https://bbangbbangz.atlassian.net/browse/EDMT-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Amplitude 기반 사용자 행동 분석 및 트래킹 기능이 추가되었습니다.
  * 페이지 뷰, 페이지 종료, 세션 시작 등 다양한 이벤트가 자동으로 기록됩니다.
  * 로그인, 로그아웃, 회원가입 시 Amplitude 사용자 정보가 연동됩니다.
  * 생활기록부 AI 기능 및 문장 확정 시 이벤트가 기록됩니다.

* **버그 수정**
  * 회원가입(/signup) 페이지가 인증 관련 미들웨어에서 제외되어 접근 제한이 해제되었습니다.

* **기타**
  * Amplitude 연동을 위한 라이브러리 및 유틸리티 함수가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->