### PR TITLE
[EDMT-225] 왈라 폼 추가 및 다양한 버그 상황 수정

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -42,27 +42,37 @@ export default function Header() {
       <Link href="/" className="pt-1 text-2xl font-bold text-black">
         EduMate
       </Link>
-      <div className="relative flex">
-        {isLogIn ? (
-          <>
-            <Image
-              src={ProfileImage}
-              alt="profile image"
-              className="hover:cursor-pointer"
-              onClick={() => setOpen((prev) => !prev)}
-              width={40}
-            />
-            {open ? (
-              <div ref={dropdownRef}>
-                <ProfileDropDown onClose={handleCloseDropdown} />
-              </div>
-            ) : null}
-          </>
-        ) : (
-          <Link href="/login" className="rounded-full bg-black px-4 py-2 text-white">
-            로그인
-          </Link>
-        )}
+      <div className="flex gap-4">
+        <a
+          href="https://walla.my/survey/tBoiYaly9xugPKLhAyRx"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-full bg-blue-600 px-4 py-2 text-white hover:bg-blue-800"
+        >
+          설문조사 참여하기
+        </a>
+        <div className="relative">
+          {isLogIn ? (
+            <>
+              <Image
+                src={ProfileImage}
+                alt="profile image"
+                className="hover:cursor-pointer"
+                onClick={() => setOpen((prev) => !prev)}
+                width={40}
+              />
+              {open ? (
+                <div ref={dropdownRef}>
+                  <ProfileDropDown onClose={handleCloseDropdown} />
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <Link href="/login" className="rounded-full bg-black px-4 py-2 text-white">
+              로그인
+            </Link>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/components/modal/delete-confirm-modal.tsx
+++ b/src/components/modal/delete-confirm-modal.tsx
@@ -11,17 +11,17 @@ import {
   ModalPortal,
 } from './base-modal';
 
-interface DeleteNoticeModalProps {
+interface DeleteConfirmModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDelete: () => void;
 }
 
-export default function DeleteNoticeModal({
+export default function DeleteConfirmModal({
   open,
   onOpenChange,
   onDelete,
-}: DeleteNoticeModalProps) {
+}: DeleteConfirmModalProps) {
   const handleCancel = () => {
     onOpenChange(false);
   };

--- a/src/components/notice/edit-delete-notice-button.tsx
+++ b/src/components/notice/edit-delete-notice-button.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-import DeleteNoticeModal from '@/components/modal/delete-notice-modal';
+import DeleteConfirmModal from '@/components/modal/delete-confirm-modal';
 import { useAuth } from '@/contexts/auth/use-auth';
 import { useDeleteAdminNotice } from '@/hooks/api/use-delete-admin-notice';
 import { revalidateNotice } from '@/lib/actions/revalidateNotice';
@@ -47,7 +47,7 @@ export default function EditDeleteNoticeButton({ id }: { id: string }) {
       >
         삭제하기
       </button>
-      <DeleteNoticeModal open={open} onOpenChange={setOpen} onDelete={handleDelete} />
+      <DeleteConfirmModal open={open} onOpenChange={setOpen} onDelete={handleDelete} />
     </div>
   ) : null;
 }

--- a/src/components/record/record-detail-edit.tsx
+++ b/src/components/record/record-detail-edit.tsx
@@ -3,6 +3,7 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 
 import { Input } from '@/components/input/input';
+import DeleteConfirmModal from '@/components/modal/delete-confirm-modal';
 import { Textarea } from '@/components/textarea/textarea';
 import { useDeleteRecordDetail } from '@/hooks/api/use-delete-record-detail';
 import { usePatchRecordDetail } from '@/hooks/api/use-patch-record-detail';
@@ -28,6 +29,8 @@ export default function RecordDetailEdit({ record, recordType, onView }: RecordD
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const [textareaHeight, setTextareaHeight] = useState<number>(0);
+
+  const [open, setOpen] = useState(false);
 
   const resizeTextarea = () => {
     const el = textareaRef.current;
@@ -55,6 +58,10 @@ export default function RecordDetailEdit({ record, recordType, onView }: RecordD
     patchRecordDetail({ recordType, updateStudentRecord }, { onSuccess: onView });
   };
 
+  const handleOpenDeleteModal = () => {
+    setOpen(true);
+  };
+
   const handleDelete = () => {
     deleteRecordDetail({ recordType, recordId: record.recordDetailId });
   };
@@ -64,51 +71,58 @@ export default function RecordDetailEdit({ record, recordType, onView }: RecordD
   }, [record.description]);
 
   return (
-    <tr className="relative">
-      <td className="py-2 pl-5">
-        <Input defaultValue={record.studentNumber} ref={studentNumberRef} className="w-full p-1" />
-      </td>
-      <td className="py-2 pl-5">
-        <Input defaultValue={record.studentName} ref={studentNameRef} className="w-full p-1" />
-      </td>
-      <td className="py-2 pl-5">
-        <Textarea
-          ref={textareaRef}
-          defaultValue={record.description}
-          className="min-h-0 w-full resize-none p-1 text-sm"
+    <>
+      <tr className="relative">
+        <td className="py-2 pl-5">
+          <Input
+            defaultValue={record.studentNumber}
+            ref={studentNumberRef}
+            className="w-full p-1"
+          />
+        </td>
+        <td className="py-2 pl-5">
+          <Input defaultValue={record.studentName} ref={studentNameRef} className="w-full p-1" />
+        </td>
+        <td className="py-2 pl-5">
+          <Textarea
+            ref={textareaRef}
+            defaultValue={record.description}
+            className="min-h-0 w-full resize-none p-1 text-sm"
+            style={{
+              lineHeight: 'inherit',
+              fontSize: 'inherit',
+              overflow: 'hidden',
+            }}
+            onInput={resizeTextarea}
+          />
+        </td>
+        <td
+          className="absolute right-0 flex gap-2 border-none"
           style={{
-            lineHeight: 'inherit',
-            fontSize: 'inherit',
-            overflow: 'hidden',
+            top: `${textareaHeight}px`,
           }}
-          onInput={resizeTextarea}
-        />
-      </td>
-      <td
-        className="absolute right-0 flex gap-2"
-        style={{
-          top: `${textareaHeight}px`,
-        }}
-      >
-        <button
-          className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
-          onClick={onView}
         >
-          취소하기
-        </button>
-        <button
-          className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
-          onClick={handleSave}
-        >
-          수정하기
-        </button>
-        <button
-          className="rounded-md bg-red-600 px-4 pb-1.5 pt-2 text-white hover:bg-red-700"
-          onClick={handleDelete}
-        >
-          삭제하기
-        </button>
-      </td>
-    </tr>
+          <button
+            className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
+            onClick={onView}
+          >
+            취소하기
+          </button>
+          <button
+            className="rounded-md bg-slate-800 px-4 pb-1.5 pt-2 text-white hover:bg-slate-950"
+            onClick={handleSave}
+          >
+            수정하기
+          </button>
+          <button
+            className="rounded-md bg-red-600 px-4 pb-1.5 pt-2 text-white hover:bg-red-700"
+            onClick={handleOpenDeleteModal}
+          >
+            삭제하기
+          </button>
+        </td>
+      </tr>
+      <DeleteConfirmModal open={open} onOpenChange={setOpen} onDelete={handleDelete} />
+    </>
   );
 }

--- a/src/components/student-record-write/ai-response.tsx
+++ b/src/components/student-record-write/ai-response.tsx
@@ -1,3 +1,4 @@
+import Loading from '@/components/loading/loading';
 import type { AiResponseData, RecordType } from '@/types/api/student-record';
 import { calculateByte } from '@/util/calculate-byte';
 
@@ -10,7 +11,12 @@ interface AiResponseProps {
 export default function AiResponse({ responses, isGenerating, recordType }: AiResponseProps) {
   const getContentForVersion = (version: number) => {
     if (isGenerating) {
-      return '생성 중입니다...';
+      return (
+        <div className="flex flex-col gap-2">
+          <Loading />
+          <p className="text-[14px] text-slate-500">20초정도 소요됩니다.</p>
+        </div>
+      );
     }
 
     if (!responses) {
@@ -40,32 +46,44 @@ export default function AiResponse({ responses, isGenerating, recordType }: AiRe
 
   return (
     <div className="flex flex-col gap-10">
-      <div className="relative">
-        <h4 className="mb-2 font-bold">(버전 1)</h4>
-        <div className="min-h-40 rounded-lg border border-slate-400 p-5">
-          <p className={`whitespace-pre-wrap ${getTextColor()}`}>{getContentForVersion(1)}</p>
+      <div className="flex flex-col gap-2">
+        <h4 className="font-bold">(버전 1)</h4>
+        <div
+          className={`min-h-40 rounded-lg border border-slate-400 p-5 ${
+            isGenerating ? 'flex items-center justify-center' : 'whitespace-pre-wrap'
+          } ${getTextColor()}`}
+        >
+          {getContentForVersion(1)}
         </div>
-        <span className="absolute bottom-1 right-2 text-slate-400">
+        <span className="flex justify-end text-slate-400">
           {getTextLength(1)}/{recordType === 'career' ? '2100' : '1500'}
         </span>
       </div>
 
-      <div className="relative">
-        <h4 className="mb-2 font-bold">(버전 2)</h4>
-        <div className="min-h-40 rounded-lg border border-slate-400 p-5">
-          <p className={`whitespace-pre-wrap ${getTextColor()}`}>{getContentForVersion(2)}</p>
+      <div className="flex flex-col gap-2">
+        <h4 className="font-bold">(버전 2)</h4>
+        <div
+          className={`min-h-40 rounded-lg border border-slate-400 p-5 ${
+            isGenerating ? 'flex items-center justify-center' : 'whitespace-pre-wrap'
+          } ${getTextColor()}`}
+        >
+          {getContentForVersion(2)}
         </div>
-        <span className="absolute bottom-1 right-2 text-slate-400">
+        <span className="flex justify-end text-slate-400">
           {getTextLength(2)}/{recordType === 'career' ? '2100' : '1500'}
         </span>
       </div>
 
-      <div className="relative">
-        <h4 className="mb-2 font-bold">(버전 3)</h4>
-        <div className="min-h-40 rounded-lg border border-slate-400 p-5">
-          <p className={`whitespace-pre-wrap ${getTextColor()}`}>{getContentForVersion(3)}</p>
+      <div className="flex flex-col gap-2">
+        <h4 className="font-bold">(버전 3)</h4>
+        <div
+          className={`min-h-40 rounded-lg border border-slate-400 p-5 ${
+            isGenerating ? 'flex items-center justify-center' : 'whitespace-pre-wrap'
+          } ${getTextColor()}`}
+        >
+          {getContentForVersion(3)}
         </div>
-        <span className="absolute bottom-1 right-2 text-slate-400">
+        <span className="flex justify-end text-slate-400">
           {getTextLength(3)}/{recordType === 'career' ? '2100' : '1500'}
         </span>
       </div>

--- a/src/components/student-record-write/record-summary.tsx
+++ b/src/components/student-record-write/record-summary.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 
-import DefaultError from '@/components/error/default-error';
+import { useRouter } from 'next/navigation';
+
 import Loading from '@/components/loading/loading';
 import SaveSummaryRecordModal from '@/components/modal/save-summary-record-modal';
 import { Textarea } from '@/components/textarea/textarea';
@@ -17,6 +18,7 @@ interface RecordSummaryProps {
 }
 
 export default function RecordSummary({ selectedId, recordType }: RecordSummaryProps) {
+  const router = useRouter();
   const [modalOpen, setModalOpen] = useState(false);
   const [description, setDescription] = useState('');
   const { mutate: postSummaryRecordDetail } = usePostSummaryRecordDetail();
@@ -54,14 +56,14 @@ export default function RecordSummary({ selectedId, recordType }: RecordSummaryP
   };
 
   if (isError) {
-    return <DefaultError />;
+    router.push(`write-${recordType}`);
   }
   if (isPending) {
     return <Loading />;
   }
 
   return (
-    <div className="relative flex flex-col gap-4">
+    <div className="flex flex-col gap-2">
       <h4 className="font-bold">종합</h4>
       <Textarea
         value={description}
@@ -69,6 +71,9 @@ export default function RecordSummary({ selectedId, recordType }: RecordSummaryP
         placeholder="완성본을 적어주세요."
         className="h-60 border-slate-400 p-5 placeholder:text-slate-400"
       />
+      <span className="flex justify-end text-slate-400">
+        {calculateByte(description)}/{recordType === 'career' ? '2100' : '1500'}
+      </span>
       <div className="flex justify-end">
         <button
           disabled={!description.trim()}
@@ -82,9 +87,7 @@ export default function RecordSummary({ selectedId, recordType }: RecordSummaryP
           저장
         </button>
       </div>
-      <span className="absolute bottom-14 right-2 text-slate-400">
-        {calculateByte(description)}/{recordType === 'career' ? '2100' : '1500'}
-      </span>
+
       <SaveSummaryRecordModal open={modalOpen} onOpenChange={setModalOpen} />
     </div>
   );

--- a/src/components/student-record-write/record-summary.tsx
+++ b/src/components/student-record-write/record-summary.tsx
@@ -56,7 +56,7 @@ export default function RecordSummary({ selectedId, recordType }: RecordSummaryP
   };
 
   if (isError) {
-    router.push(`write-${recordType}`);
+    router.push(`/write-${recordType}`);
   }
   if (isPending) {
     return <Loading />;

--- a/src/contexts/auth/auth-provider.tsx
+++ b/src/contexts/auth/auth-provider.tsx
@@ -11,6 +11,7 @@ import { AuthContext } from './auth-context';
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     const initializeAuth = async () => {
@@ -28,11 +29,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
       } catch {
         setAccessToken(null);
+      } finally {
+        setIsReady(true);
       }
     };
 
     initializeAuth();
   }, []);
+
+  if (!isReady) return null;
 
   return (
     <AuthContext.Provider value={{ accessToken, setAccessToken, isAdmin, setIsAdmin }}>

--- a/src/hooks/api/use-get-records.ts
+++ b/src/hooks/api/use-get-records.ts
@@ -11,7 +11,7 @@ export const useGetRecords = (recordType: RecordType) => {
   const query = useQuery<StudentsResponse>({
     queryKey: ['records', recordType],
     queryFn: () => getRecords({ recordType, accessToken, semester: '2025-1' }),
-    retry: 1,
+    retry: 0,
   });
 
   return {

--- a/src/hooks/api/use-get-students-name.ts
+++ b/src/hooks/api/use-get-students-name.ts
@@ -11,11 +11,7 @@ export const useGetStudentsName = (recordType: RecordType, semester: string) => 
   const query = useQuery<StudentNameTypes[]>({
     queryKey: ['studentsName', recordType],
     queryFn: () => getStudentsName(recordType, semester, accessToken),
-    retry: 1,
-    staleTime: 10 * 60 * 1000,
-    gcTime: 30 * 60 * 1000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    retry: 0,
   });
 
   return {

--- a/src/hooks/api/use-get-summary-record-detail.ts
+++ b/src/hooks/api/use-get-summary-record-detail.ts
@@ -15,5 +15,6 @@ export const useGetSummaryRecordDetail = (recordId: number) => {
     gcTime: 10 * 60 * 1000,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
+    retry: 0,
   });
 };

--- a/src/util/download-excel.ts
+++ b/src/util/download-excel.ts
@@ -3,6 +3,8 @@ import { saveAs } from 'file-saver';
 
 import type { RecordType, StudentRecord } from '@/types/api/student-record';
 
+import { getYearAndMonthAndDay } from './get-korea-formatted-time-stamp';
+
 const recordTypeToTitle: Record<RecordType, string> = {
   subject: '세부능력 및 특기사항',
   behavior: '행동특성 및 종합의견',
@@ -12,7 +14,7 @@ const recordTypeToTitle: Record<RecordType, string> = {
 };
 
 export const downloadExcel = async (data: StudentRecord[], recordType: RecordType) => {
-  const title = recordTypeToTitle[recordType];
+  const title = `${recordTypeToTitle[recordType]} ${getYearAndMonthAndDay()}`;
 
   const workbook = new ExcelJS.Workbook();
   const worksheet = workbook.addWorksheet(title);
@@ -20,7 +22,7 @@ export const downloadExcel = async (data: StudentRecord[], recordType: RecordTyp
   worksheet.columns = [
     { header: '학번', key: 'studentNumber', width: 15 },
     { header: '이름', key: 'name', width: 15 },
-    { header: title, key: 'description', width: 300 },
+    { header: recordTypeToTitle[recordType], key: 'description', width: 300 },
   ];
 
   const extractData = data.map((record) => ({

--- a/src/util/get-korea-formatted-time-stamp.ts
+++ b/src/util/get-korea-formatted-time-stamp.ts
@@ -13,3 +13,16 @@ export const getKoreaFormattedTimeStamp = (): string => {
 
   return `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss}`;
 };
+
+export const getYearAndMonthAndDay = (): string => {
+  const now = new Date();
+
+  const kstString = now.toLocaleString('en-US', { timeZone: 'Asia/Seoul' });
+  const kstDate = new Date(kstString);
+
+  const yyyy = kstDate.getFullYear();
+  const mm = String(kstDate.getMonth() + 1).padStart(2, '0');
+  const dd = String(kstDate.getDate()).padStart(2, '0');
+
+  return `${yyyy}-${mm}-${dd}`;
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-225]

## 🌱 주요 변경 사항

1. 헤더에 사용자 설문조사를 받기 위한 walla 링크 추가
2. 나의 학생 관리에서 작성한 생기부 삭제를 누르면 정말 삭제할건지 물어보는 모달 추가 및 삭제 모달 이름 수정
3. 자주 error가 나오는 api들 retry : 0 옵션을 추가하면서 사용자에게 빠르게 error ui를 보여주도록 수정
4. ai 생성 버튼을 클릭할때 기존에 "생성중입니다" 에서 Loading 컴포넌트로 바꾸고 20초 정도 걸린다는 안내 메세지 추가
5. 새로고침 시 reissue api 호출 전에 다른 api 호출이 일어나는 버그 상황을 막기 위해 isReady 상태 추가
6. excel 추출 함수에서 현재 날짜 추가

## 📸 스크린샷 (선택)
<img width="1710" alt="스크린샷 2025-06-29 오후 5 29 08" src="https://github.com/user-attachments/assets/5ece5f52-7172-42ba-90d5-b28df49d1d89" />




[EDMT-225]: https://bbangbbangz.atlassian.net/browse/EDMT-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 헤더 우측에 "설문조사 참여하기" 외부 링크 버튼이 추가되었습니다.
  * 엑셀 다운로드 시 파일명과 워크시트 제목에 현재 날짜(YYYY-MM-DD)가 포함됩니다.

* **버그 수정**
  * 인증 초기화가 완료될 때까지 화면이 표시되지 않도록 개선되어, 인증 상태가 정확히 반영됩니다.

* **UI/UX 개선**
  * 삭제 버튼 클릭 시 삭제 확인 모달이 적용되어 실수로 인한 삭제를 방지합니다.
  * AI 응답 생성 중 로딩 스피너와 안내 메시지가 표시됩니다.
  * 텍스트 입력란의 바이트 수 표시 위치와 스타일이 개선되었습니다.
  * 오류 발생 시 클라이언트 측에서 관련 페이지로 자동 이동하도록 변경되었습니다.

* **기타 변경**
  * 일부 내부 명칭 및 컴포넌트 이름이 더 명확하게 변경되었습니다.
  * 데이터 조회 실패 시 자동 재시도 횟수가 0으로 변경되어, 실패 시 즉시 에러가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->