### PR TITLE
[EDMT-217] e2e test를 위한 playwright 설치 및 랜딩 페이지 e2e test case 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint",
     "prepare": "husky",
     "precommit": "pnpm lint-staged",
-    "mock-server": "tsx src/mock-server/server.ts"
+    "mock-server": "tsx src/mock-server/server.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
@@ -46,6 +48,7 @@
     "@eslint/eslintrc": "^3",
     "@eslint/js": "^9.26.0",
     "@mswjs/http-middleware": "^0.10.3",
+    "@playwright/test": "^1.53.1",
     "@types/express": "^5.0.2",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 0.511.0(react@18.3.1)
       next:
         specifier: 14.2.26
-        version: 14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.26(@playwright/test@1.53.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -87,6 +87,9 @@ importers:
       '@mswjs/http-middleware':
         specifier: ^0.10.3
         version: 0.10.3(msw@2.10.2(@types/node@20.19.1)(typescript@5.8.3))
+      '@playwright/test':
+        specifier: ^1.53.1
+        version: 1.53.1
       '@types/express':
         specifier: ^5.0.2
         version: 5.0.3
@@ -680,6 +683,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.53.1':
+    resolution: {integrity: sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
@@ -2035,6 +2043,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2880,6 +2893,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.53.1:
+    resolution: {integrity: sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.53.1:
+    resolution: {integrity: sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4191,6 +4214,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.53.1':
+    dependencies:
+      playwright: 1.53.1
 
   '@radix-ui/primitive@1.1.2': {}
 
@@ -5847,6 +5874,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6462,7 +6492,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@14.2.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.26(@playwright/test@1.53.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.26
       '@swc/helpers': 0.5.5
@@ -6483,6 +6513,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.26
       '@next/swc-win32-ia32-msvc': 14.2.26
       '@next/swc-win32-x64-msvc': 14.2.26
+      '@playwright/test': 1.53.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -6641,6 +6672,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.53.1: {}
+
+  playwright@1.53.1:
+    dependencies:
+      playwright-core: 1.53.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/landing-page.spec.ts
+++ b/tests/landing-page.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EduMate 랜딩 페이지', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('페이지 메타데이터가 올바르게 설정되어 있다', async ({ page }) => {
+    await expect(page).toHaveTitle('EduMate');
+
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveAttribute(
+      'content',
+      '교사를 위한 AI 기반 생활기록부 작성 및 관리 서비스',
+    );
+
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('lang', 'ko');
+  });
+
+  test('랜딩 페이지 이미지가 표시된다', async ({ page }) => {
+    const landingImage = page.locator('img[alt="랜딩 페이지 이미지"]');
+
+    await expect(landingImage).toBeVisible();
+    await expect(landingImage).toHaveAttribute('width', '1000');
+  });
+
+  test('학생 관리 카드가 보여야 하고, 링크로 이동해야 한다', async ({ page }) => {
+    const link = page.getByRole('link', { name: /나의 학생 관리/i });
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page).toHaveURL(/\/manage-subject/);
+  });
+
+  test('생기부 작성 카드가 보여야 하고, 링크로 이동해야 한다', async ({ page }) => {
+    const link = page.getByRole('link', { name: /생기부 작성 기능/i });
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page).toHaveURL(/\/write-subject/);
+  });
+
+  test('페이지가 빠르게 로드된다', async ({ page }) => {
+    const startTime = Date.now();
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const loadTime = Date.now() - startTime;
+    expect(loadTime).toBeLessThan(5000);
+
+    await expect(page.locator('img[alt="랜딩 페이지 이미지"]')).toBeVisible();
+
+    await expect(page.getByRole('link', { name: /나의 학생 관리/ })).toBeVisible();
+    await expect(page.getByRole('link', { name: /생기부 작성 기능/ })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-217]

## 🌱 주요 변경 사항

1. playwright 설치 및 기초 세팅, package.json에 스크립트 추가
2. 랜딩페이지 e2e test case 추가

## 📸 스크린샷 (선택)

<img width="1277" alt="스크린샷 2025-06-30 오전 1 19 07" src="https://github.com/user-attachments/assets/abfd3e9a-d13a-43e9-bb48-9da43bb0faa8" />


[EDMT-217]: https://bbangbbangz.atlassian.net/browse/EDMT-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Playwright 기반의 E2E(엔드투엔드) 테스트 환경이 추가되었습니다.
  * 랜딩 페이지에 대한 자동화 테스트가 도입되어 주요 요소와 내비게이션, 성능 등이 검증됩니다.

* **테스트**
  * E2E 테스트 실행 및 UI 모드 실행을 위한 npm 스크립트가 추가되었습니다.
  * Playwright 테스트 프레임워크가 개발 의존성으로 도입되었습니다.

* **잡무(Chores)**
  * Playwright 관련 파일과 결과물, 캐시 등이 버전 관리에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->