### PR TITLE
[EDMT-242] 마이 프로필 수정 기능 구현 및 의존성 분리

### DIFF
--- a/src/components/mypage/mypage.tsx
+++ b/src/components/mypage/mypage.tsx
@@ -2,33 +2,25 @@
 
 import { useState } from 'react';
 
-import { CheckCircle2 } from 'lucide-react';
-
-import Image from 'next/image';
 import Link from 'next/link';
 
 import Loading from '@/components/loading/loading';
-import EmailSentModal from '@/components/modal/email-sent-modal';
 import { useGetProfile } from '@/hooks/api/use-get-profile';
-import { usePostSendEmail } from '@/hooks/api/use-post-send-email';
 
-import ProfileImage from '../../../public/images/profile-image.png';
+import ProfileEdit from './profile-edit';
+import ProfileView from './profile-view';
 
 export default function Mypage() {
   const { data, isPending, isError } = useGetProfile();
-  const [open, setOpen] = useState(false);
 
-  const { mutate: postSendEmail } = usePostSendEmail();
+  const [isEditing, setIsEditing] = useState(false);
 
-  const handleSendEmail = () => {
-    postSendEmail(undefined, {
-      onSuccess: () => {
-        setOpen(true);
-      },
-      onError: (error) => {
-        alert(error.message);
-      },
-    });
+  const handleOnEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleOnView = () => {
+    setIsEditing(false);
   };
 
   if (isError) {
@@ -51,43 +43,13 @@ export default function Mypage() {
   return (
     <div className="flex flex-col gap-5 px-10">
       <h2 className="text-[30px] font-bold">내 프로필</h2>
-      <div className="mt-5 flex gap-4">
-        <Image src={ProfileImage} alt="profile image" width={100} />
-        <div className="flex flex-col justify-center gap-1">
-          <span className="text-lg font-bold">{data.nickname}</span>
-          <div>
-            <span className="text-sm text-slate-600">인증 상태 : </span>
-            {data.isTeacherVerified ? (
-              <span className="text-sm font-bold">교사 인증 완료</span>
-            ) : (
-              <span
-                onClick={handleSendEmail}
-                className="text-sm text-red-500 underline hover:cursor-pointer"
-              >
-                교사 인증 필요
-              </span>
-            )}
-          </div>
-          <div>
-            <span className="text-sm text-slate-600">과목 : </span>
-            <span className="text-sm font-bold">{data.subject}</span>
-          </div>
-        </div>
-      </div>
-      <div className="mb-14 flex gap-4">
-        <div
-          className={`flex gap-2 rounded-full px-4 py-2 ${data.school === 'middle' ? 'bg-slate-800 text-white' : 'bg-slate-200'}`}
-        >
-          <CheckCircle2 width={20} />
-          <span className="pt-[2px] text-sm">중학교</span>
-        </div>
-        <div
-          className={`flex gap-2 rounded-full px-4 py-2 ${data.school === 'high' ? 'bg-slate-800 text-white' : 'bg-slate-200'}`}
-        >
-          <CheckCircle2 width={20} />
-          <span className="pt-[2px] text-sm">고등학교</span>
-        </div>
-      </div>
+
+      {isEditing ? (
+        <ProfileEdit profile={data} onChangeView={handleOnView} />
+      ) : (
+        <ProfileView profile={data} onChangeEdit={handleOnEdit} />
+      )}
+
       <h2 className="text-[30px] font-bold">기본 정보</h2>
       <hr />
       <div className="flex w-full gap-10 px-4">
@@ -100,7 +62,6 @@ export default function Mypage() {
         <span className="pt-1 text-lg">********</span>
       </div>
       <hr />
-      <EmailSentModal open={open} onOpenChange={setOpen} />
     </div>
   );
 }

--- a/src/components/mypage/profile-edit.tsx
+++ b/src/components/mypage/profile-edit.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+
+import { CheckCircle2, ChevronDown } from 'lucide-react';
+
+import { Input } from '@/components/input/input';
+import { subjects } from '@/constants/signup-data';
+import { useGetCheckValidNickname } from '@/hooks/api/use-get-check-valid-nickname';
+import { usePatchProfile } from '@/hooks/api/use-patch-profile';
+import type { UserInfoTypes } from '@/types/api/auth';
+
+interface ProfileEditProps {
+  profile: UserInfoTypes;
+  onChangeView: () => void;
+}
+
+export default function ProfileEdit({ profile, onChangeView }: ProfileEditProps) {
+  const [nickname, setNickname] = useState(profile.nickname);
+  const [subject, setSubject] = useState(profile.subject);
+  const [school, setSchool] = useState(profile.school);
+  const [isSubjectDropdownOpen, setIsSubjectDropdownOpen] = useState(false);
+  const [isCheckingNickname, setIsCheckingNickname] = useState(true);
+
+  const { mutate: getCheckValidNickname, isPending: isCheckingValidNickname } =
+    useGetCheckValidNickname();
+
+  const { mutate: patchProfile, isPending } = usePatchProfile();
+
+  const handleSchoolChange = (school: 'middle' | 'high') => {
+    setSchool(school);
+  };
+
+  const handleNicknameCheck = () => {
+    getCheckValidNickname(nickname, {
+      onSuccess: (data) => {
+        if (!data.isDuplicated && !data.isInvalid) {
+          setIsCheckingNickname(true);
+          alert('사용 가능한 닉네임입니다!');
+        } else if (data.isDuplicated) {
+          alert('현재 사용 중인 닉네임입니다.');
+        } else if (data.isInvalid) {
+          alert('금칙어가 들어갔습니다. 다른 닉네임을 사용해주세요.');
+        }
+      },
+    });
+  };
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    if (e.target.value !== profile.nickname) {
+      setIsCheckingNickname(false);
+    } else {
+      setIsCheckingNickname(true);
+    }
+  };
+
+  const handleSave = () => {
+    if (nickname !== profile.nickname && !isCheckingNickname) {
+      alert('닉네임 중복확인을 해주세요.');
+      return;
+    }
+
+    patchProfile(
+      {
+        nickname,
+        subject,
+        school,
+      },
+      {
+        onSuccess: onChangeView,
+      },
+    );
+  };
+
+  const handleSubjectSelect = (selectedSubject: string) => {
+    setSubject(selectedSubject);
+    setIsSubjectDropdownOpen(false);
+  };
+
+  return (
+    <div className="mb-[30px] mt-5 space-y-3">
+      <div className="space-y-2">
+        <div className="flex items-center gap-4">
+          <span className="w-16 text-sm text-slate-600">닉네임</span>
+          <Input
+            value={nickname}
+            onChange={handleNicknameChange}
+            className="max-w-xs flex-1"
+            placeholder="닉네임을 입력하세요"
+          />
+          <button
+            onClick={handleNicknameCheck}
+            disabled={!nickname.trim() || isCheckingValidNickname}
+            className="rounded-md bg-slate-800 px-4 py-1.5 text-white hover:bg-slate-950 disabled:cursor-not-allowed disabled:bg-gray-400"
+          >
+            {isCheckingValidNickname ? '중복 확인 중...' : '중복 확인'}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <span className="w-16 text-sm text-slate-600">과목</span>
+        <div className="relative max-w-xs flex-1">
+          <button
+            onClick={() => setIsSubjectDropdownOpen(!isSubjectDropdownOpen)}
+            className="w-full rounded-md border border-gray-300 bg-white p-2 text-left hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {subject || '과목을 선택하세요'}
+            <div className="float-right">
+              <ChevronDown />
+            </div>
+          </button>
+
+          {isSubjectDropdownOpen ? (
+            <div className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg">
+              {subjects.map((subjectOption) => (
+                <button
+                  key={subjectOption.value}
+                  onClick={() => handleSubjectSelect(subjectOption.value)}
+                  className={`w-full px-3 py-2 text-left hover:bg-gray-100 ${
+                    subject === subjectOption.value ? 'bg-blue-50 text-blue-600' : ''
+                  }`}
+                >
+                  {subjectOption.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-start gap-4">
+        <span className="w-16 pt-2 text-sm text-slate-600">학교</span>
+        <div className="flex gap-4">
+          <button
+            onClick={() => handleSchoolChange('middle')}
+            className={`flex gap-2 rounded-full px-4 py-2 transition-colors ${
+              school === 'middle' ? 'bg-slate-800 text-white' : 'bg-slate-200 hover:bg-slate-300'
+            }`}
+          >
+            <CheckCircle2 width={20} />
+            <span className="pt-[2px] text-sm">중학교</span>
+          </button>
+          <button
+            onClick={() => handleSchoolChange('high')}
+            className={`flex gap-2 rounded-full px-4 py-2 transition-colors ${
+              school === 'high' ? 'bg-slate-800 text-white' : 'bg-slate-200 hover:bg-slate-300'
+            }`}
+          >
+            <CheckCircle2 width={20} />
+            <span className="pt-[2px] text-sm">고등학교</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="flex gap-3 pt-4">
+        <button
+          onClick={onChangeView}
+          className="rounded-md bg-gray-200 px-4 py-2 text-gray-600 hover:bg-gray-300"
+          disabled={isPending}
+        >
+          취소
+        </button>
+        <button
+          onClick={handleSave}
+          className="rounded-md bg-slate-800 px-4 py-2 text-white hover:bg-slate-950 disabled:cursor-not-allowed disabled:bg-gray-400"
+          disabled={isPending || !isCheckingNickname}
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mypage/profile-view.tsx
+++ b/src/components/mypage/profile-view.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+
+import { CheckCircle2 } from 'lucide-react';
+
+import Image from 'next/image';
+
+import EmailSentModal from '@/components/modal/email-sent-modal';
+import { usePostSendEmail } from '@/hooks/api/use-post-send-email';
+import type { UserInfoTypes } from '@/types/api/auth';
+
+import ProfileImage from '../../../public/images/profile-image.png';
+
+interface ProfileViewProps {
+  profile: UserInfoTypes;
+  onChangeEdit: () => void;
+}
+
+export default function ProfileView({ profile, onChangeEdit }: ProfileViewProps) {
+  const [open, setOpen] = useState(false);
+
+  const { mutate: postSendEmail } = usePostSendEmail();
+
+  const handleSendEmail = () => {
+    postSendEmail(undefined, {
+      onSuccess: () => {
+        setOpen(true);
+      },
+      onError: (error) => {
+        alert(error.message);
+      },
+    });
+  };
+
+  return (
+    <div className="mb-10 flex flex-col gap-5">
+      <div className="flex gap-4">
+        <Image src={ProfileImage} alt="profile image" width={100} />
+        <div className="flex flex-col justify-center gap-1">
+          <div className="flex items-center gap-3">
+            <span className="text-lg font-bold">{profile.nickname}</span>
+          </div>
+          <div>
+            <span className="text-sm text-slate-600">인증 상태 : </span>
+            {profile.isTeacherVerified ? (
+              <span className="text-sm font-bold">교사 인증 완료</span>
+            ) : (
+              <span
+                onClick={handleSendEmail}
+                className="text-sm text-red-500 underline hover:cursor-pointer"
+              >
+                교사 인증 필요
+              </span>
+            )}
+          </div>
+          <div>
+            <span className="text-sm text-slate-600">과목 : </span>
+            <span className="text-sm font-bold">{profile.subject}</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex gap-4">
+        <div
+          className={`flex gap-2 rounded-full px-4 py-2 ${profile.school === 'middle' ? 'bg-slate-800 text-white' : 'bg-slate-200'}`}
+        >
+          <CheckCircle2 width={20} />
+          <span className="pt-[2px] text-sm">중학교</span>
+        </div>
+        <div
+          className={`flex gap-2 rounded-full px-4 py-2 ${profile.school === 'high' ? 'bg-slate-800 text-white' : 'bg-slate-200'}`}
+        >
+          <CheckCircle2 width={20} />
+          <span className="pt-[2px] text-sm">고등학교</span>
+        </div>
+      </div>
+      <button
+        onClick={onChangeEdit}
+        className="w-40 rounded-md bg-blue-800 px-6 py-2 text-white hover:bg-blue-950"
+      >
+        프로필 수정하기
+      </button>
+      <EmailSentModal open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/src/hooks/api/use-get-check-valid-nickname.ts
+++ b/src/hooks/api/use-get-check-valid-nickname.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useAuth } from '@/contexts/auth/use-auth';
+import { getCheckValidNickname } from '@/services/auth/get-check-valid-nickname';
+import type { GetCheckValidNicknameResponse } from '@/types/api/auth';
+
+export const useGetCheckValidNickname = () => {
+  const { accessToken } = useAuth();
+
+  return useMutation<GetCheckValidNicknameResponse, Error, string>({
+    mutationFn: (nickname) => getCheckValidNickname({ nickname, accessToken }),
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+};

--- a/src/hooks/api/use-patch-profile.ts
+++ b/src/hooks/api/use-patch-profile.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useAuth } from '@/contexts/auth/use-auth';
+import { patchProfile } from '@/services/auth/patch-profile';
+import type { PatchProfileProps } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const usePatchProfile = () => {
+  const { accessToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation<Response<null>, Error, PatchProfileProps>({
+    mutationFn: (params) => patchProfile({ ...params, accessToken }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['profile'],
+      });
+    },
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+};

--- a/src/services/auth/get-check-valid-nickname.ts
+++ b/src/services/auth/get-check-valid-nickname.ts
@@ -1,0 +1,27 @@
+import type { GetCheckValidNicknameRequest, GetCheckValidNicknameResponse } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const getCheckValidNickname = async ({
+  nickname,
+  accessToken,
+}: GetCheckValidNicknameRequest) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/nickname?nickname=${nickname}`,
+    {
+      headers: {
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+    },
+  );
+
+  const json: Response<GetCheckValidNicknameResponse> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '닉네임 변경 실패');
+  }
+  if (!json.data) {
+    throw new Error('응답에 데이터가 없습니다.');
+  }
+
+  return json.data;
+};

--- a/src/services/auth/patch-profile.ts
+++ b/src/services/auth/patch-profile.ts
@@ -1,0 +1,26 @@
+import type { PatchProfile } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const patchProfile = async ({
+  subject,
+  school,
+  nickname,
+  accessToken,
+}: PatchProfile): Promise<Response<null>> => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/profile`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ subject, school, nickname }),
+  });
+
+  const json: Response<null> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '프로필 수정 실패');
+  }
+
+  return json;
+};

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -24,3 +24,26 @@ export type UserInfoTypes = {
   school: string;
   nickname: string;
 };
+
+export type PatchProfileProps = {
+  subject: string;
+  school: string;
+  nickname: string;
+};
+
+export type PatchProfile = {
+  subject: string;
+  school: string;
+  nickname: string;
+  accessToken: string | null;
+};
+
+export type GetCheckValidNicknameResponse = {
+  isInvalid: boolean;
+  isDuplicated: boolean;
+};
+
+export type GetCheckValidNicknameRequest = {
+  nickname: string;
+  accessToken: string | null;
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-242]

## 🌱 주요 변경 사항
1. 마이프로필 View, Edit 컴포넌트 분리
2. 닉네임 중복 확인 api로직 구현 및 useMutation으로 추상화
3. 프로필 수정 api 로직 구현 및 useMutation으로 추상화
4. 프로필 수정에 필요한 types 추가

## 📸 스크린샷 (선택)

<img width="1710" alt="스크린샷 2025-07-06 오후 3 44 34" src="https://github.com/user-attachments/assets/718d4545-81c2-4899-9ca2-9d9fe6624477" />


[EDMT-242]: https://bbangbbangz.atlassian.net/browse/EDMT-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 보기와 편집을 위한 새로운 화면이 추가되었습니다.
  * 닉네임 중복 및 유효성 검사가 지원됩니다.
  * 과목 및 학교(중/고등학교) 선택 기능이 개선되었습니다.
  * 프로필 수정 시 실시간 유효성 확인 및 저장 기능이 제공됩니다.

* **버그 수정**
  * 이전 교사 인증 이메일 발송 및 안내 모달 관련 UI와 로직이 제거되어 불필요한 동작이 사라졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->