### PR TITLE
[EDMT-219] 기본정보인 이메일, 비밀번호 수정 기능 구현

### DIFF
--- a/src/components/mypage/basic-info-email-edit.tsx
+++ b/src/components/mypage/basic-info-email-edit.tsx
@@ -1,0 +1,79 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { Input } from '@/components/input/input';
+import { emailSchema } from '@/components/signup/signup-scheme';
+import { usePatchEmail } from '@/hooks/api/use-patch-email';
+
+const emailEditSchema = z.object({
+  email: emailSchema,
+});
+
+type EmailEditType = z.infer<typeof emailEditSchema>;
+
+interface EmailEditProps {
+  currentEmail: string;
+  onView: () => void;
+}
+
+export default function BasicInfoEmailEdit({ currentEmail, onView }: EmailEditProps) {
+  const { mutate: patchEmail, isPending } = usePatchEmail();
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<EmailEditType>({
+    resolver: zodResolver(emailEditSchema),
+    defaultValues: {
+      email: currentEmail,
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = (data: EmailEditType) => {
+    patchEmail(data.email, {
+      onSuccess: () => {
+        alert('이메일이 성공적으로 변경되었습니다.');
+        onView();
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex w-full items-center gap-4">
+      <span className="text-slate-500">이메일</span>
+      <div className="relative ml-4 flex flex-1">
+        <Input
+          className={`h-8 text-lg ${
+            errors.email ? 'border border-red-500 focus-visible:border-2 focus-visible:ring-0' : ''
+          }`}
+          type="email"
+          placeholder="새로운 이메일을 입력해주세요"
+          {...register('email')}
+        />
+        {errors.email ? (
+          <p className="absolute top-9 text-xs text-red-500">{errors.email.message}</p>
+        ) : null}
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onView}
+          className="rounded-lg bg-gray-200 px-4 py-1 text-gray-600 hover:bg-gray-300"
+          disabled={isPending}
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          className="rounded-lg bg-slate-800 px-4 py-1 text-white hover:bg-slate-950 disabled:cursor-not-allowed disabled:bg-gray-400"
+          disabled={isPending}
+        >
+          저장
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/mypage/basic-info-password-edit.tsx
+++ b/src/components/mypage/basic-info-password-edit.tsx
@@ -1,0 +1,131 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { Input } from '@/components/input/input';
+import { passwordSchema } from '@/components/signup/signup-scheme';
+import { usePatchAfterLoginPassword } from '@/hooks/api/use-patch-after-login-password';
+
+const passwordEditSchema = z
+  .object({
+    currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요.'),
+    newPassword: passwordSchema,
+    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: '새 비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });
+
+type PasswordEditType = z.infer<typeof passwordEditSchema>;
+
+interface PasswordEditProps {
+  onView: () => void;
+}
+
+export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
+  const { mutate: patchAfterLoginPassword, isPending } = usePatchAfterLoginPassword();
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+    reset,
+  } = useForm<PasswordEditType>({
+    resolver: zodResolver(passwordEditSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmit = (data: PasswordEditType) => {
+    patchAfterLoginPassword(
+      {
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+      },
+      {
+        onSuccess: () => {
+          alert('비밀번호가 성공적으로 변경되었습니다.');
+          reset();
+          onView();
+        },
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <div className="flex w-full items-center gap-7">
+        <span className="text-slate-500">비밀번호</span>
+        <div className="flex flex-1 flex-col gap-1">
+          <div className="space-y-3">
+            <Input
+              className={`h-10 text-lg ${
+                errors.currentPassword
+                  ? 'border border-red-500 focus-visible:border-2 focus-visible:ring-0'
+                  : ''
+              }`}
+              type="password"
+              placeholder="현재 비밀번호"
+              {...register('currentPassword')}
+            />
+            <Input
+              className={`h-10 text-lg ${
+                errors.newPassword
+                  ? 'border border-red-500 focus-visible:border-2 focus-visible:ring-0'
+                  : ''
+              }`}
+              type="password"
+              placeholder="새 비밀번호"
+              {...register('newPassword')}
+            />
+            <Input
+              className={`h-10 text-lg ${
+                errors.confirmPassword
+                  ? 'border border-red-500 focus-visible:border-2 focus-visible:ring-0'
+                  : ''
+              }`}
+              type="password"
+              placeholder="새 비밀번호 확인"
+              {...register('confirmPassword')}
+            />
+          </div>
+          {errors.currentPassword || errors.newPassword || errors.confirmPassword ? (
+            <div className="space-y-1">
+              {errors.currentPassword ? (
+                <p className="text-xs text-red-500">{errors.currentPassword.message}</p>
+              ) : null}
+              {errors.newPassword ? (
+                <p className="text-xs text-red-500">{errors.newPassword.message}</p>
+              ) : null}
+              {errors.confirmPassword ? (
+                <p className="text-xs text-red-500">{errors.confirmPassword.message}</p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onView}
+            className="rounded-lg bg-gray-200 px-4 py-1 text-gray-600 hover:bg-gray-300"
+            disabled={isPending}
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            className="rounded-lg bg-slate-800 px-4 py-1 text-white hover:bg-slate-950 disabled:cursor-not-allowed disabled:bg-gray-400"
+            disabled={isPending}
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/mypage/basic-info.tsx
+++ b/src/components/mypage/basic-info.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+import BasicInfoEmailEdit from './basic-info-email-edit';
+import BasicInfoPasswordEdit from './basic-info-password-edit';
+
+export default function BasicInfo({ email }: { email: string }) {
+  const [editMode, setEditMode] = useState<'email' | 'password' | null>(null);
+
+  const handleOnView = () => {
+    setEditMode(null);
+  };
+
+  return (
+    <div>
+      <hr />
+      {editMode === 'email' ? (
+        <div className="px-4 py-6">
+          <BasicInfoEmailEdit currentEmail={email} onView={handleOnView} />
+        </div>
+      ) : (
+        <div className="flex w-full items-center justify-between gap-10 px-4 py-6">
+          <div className="flex gap-10 pt-1">
+            <span className="text-slate-500">이메일</span>
+            <span className="text-lg">{email}</span>
+          </div>
+          {editMode !== 'password' ? (
+            <button
+              onClick={() => setEditMode('email')}
+              className="rounded-lg bg-slate-800 px-4 py-1 text-white hover:bg-slate-950"
+            >
+              수정
+            </button>
+          ) : null}
+        </div>
+      )}
+      <hr />
+      {editMode === 'password' ? (
+        <div className="px-4 py-6">
+          <BasicInfoPasswordEdit onView={handleOnView} />
+        </div>
+      ) : (
+        <div className="flex w-full items-center justify-between gap-7 px-4 py-6">
+          <div className="flex gap-7 pt-1">
+            <span className="text-slate-500">비밀번호</span>
+            <span className="pt-1 text-lg">********</span>
+          </div>
+          {editMode !== 'email' ? (
+            <button
+              onClick={() => setEditMode('password')}
+              className="rounded-lg bg-slate-800 px-4 py-1 text-white hover:bg-slate-950"
+            >
+              수정
+            </button>
+          ) : null}
+        </div>
+      )}
+      <hr />
+    </div>
+  );
+}

--- a/src/components/mypage/mypage.tsx
+++ b/src/components/mypage/mypage.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import Loading from '@/components/loading/loading';
 import { useGetProfile } from '@/hooks/api/use-get-profile';
 
+import BasicInfo from './basic-info';
 import ProfileEdit from './profile-edit';
 import ProfileView from './profile-view';
 
@@ -51,17 +52,7 @@ export default function Mypage() {
       )}
 
       <h2 className="text-[30px] font-bold">기본 정보</h2>
-      <hr />
-      <div className="flex w-full gap-10 px-4">
-        <span className="text-slate-500">이메일</span>
-        <span className="text-lg">{data.email}</span>
-      </div>
-      <hr />
-      <div className="flex w-full gap-7 px-4">
-        <span className="text-slate-500">비밀번호</span>
-        <span className="pt-1 text-lg">********</span>
-      </div>
-      <hr />
+      <BasicInfo email={data.email} />
     </div>
   );
 }

--- a/src/hooks/api/use-patch-after-login-password.ts
+++ b/src/hooks/api/use-patch-after-login-password.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useAuth } from '@/contexts/auth/use-auth';
+import { patchAfterLoginPassword } from '@/services/auth/patch-after-login-password';
+import type { PatchAfterLoginPasswordProps } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const usePatchAfterLoginPassword = () => {
+  const { accessToken } = useAuth();
+
+  return useMutation<Response<null>, Error, PatchAfterLoginPasswordProps>({
+    mutationFn: (params) => patchAfterLoginPassword({ ...params, accessToken }),
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+};

--- a/src/hooks/api/use-patch-email.ts
+++ b/src/hooks/api/use-patch-email.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useAuth } from '@/contexts/auth/use-auth';
+import { patchEmail } from '@/services/auth/patch-email';
+import type { Response } from '@/types/api/response';
+
+export const usePatchEmail = () => {
+  const { accessToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation<Response<null>, Error, string>({
+    mutationFn: (email) => patchEmail({ email, accessToken }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['profile'],
+      });
+    },
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+};

--- a/src/services/auth/patch-after-login-password.ts
+++ b/src/services/auth/patch-after-login-password.ts
@@ -1,0 +1,25 @@
+import type { PatchAfterLoginPassword } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const patchAfterLoginPassword = async ({
+  currentPassword,
+  newPassword,
+  accessToken,
+}: PatchAfterLoginPassword): Promise<Response<null>> => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/password`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+
+  const json: Response<null> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '비밀번호 수정 실패');
+  }
+
+  return json;
+};

--- a/src/services/auth/patch-email.ts
+++ b/src/services/auth/patch-email.ts
@@ -1,0 +1,21 @@
+import type { PatchEmail } from '@/types/api/auth';
+import type { Response } from '@/types/api/response';
+
+export const patchEmail = async ({ email, accessToken }: PatchEmail): Promise<Response<null>> => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/email`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ email }),
+  });
+
+  const json: Response<null> = await res.json();
+
+  if (!res.ok) {
+    throw new Error(json.message || '이메일 수정 실패');
+  }
+
+  return json;
+};

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -47,3 +47,19 @@ export type GetCheckValidNicknameRequest = {
   nickname: string;
   accessToken: string | null;
 };
+
+export type PatchEmail = {
+  email: string;
+  accessToken: string | null;
+};
+
+export type PatchAfterLoginPasswordProps = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+export type PatchAfterLoginPassword = {
+  currentPassword: string;
+  newPassword: string;
+  accessToken: string | null;
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-219]

## 🌱 주요 변경 사항

1. 이메일 변경 api 구현 및 useMutation으로 추상화
2. 비밀번호 api 구현 및 useMutation으로 추상화
3. 마이페이지에서 기본정보 컴포넌트 분리
4. 이메일 변경 컴포넌트 구현 및 api 연동
5. 비밀번호 변경 컴포넌트 구현 및 api 연동
6. 이메일, 비밀번호 변경에 필요한 types 추가

## 📸 스크린샷 (선택)
<img width="1346" alt="스크린샷 2025-07-06 오후 5 22 21" src="https://github.com/user-attachments/assets/3a191777-cef9-4ea8-9853-a2250ec8d9eb" />


<img width="1346" alt="스크린샷 2025-07-06 오후 5 22 14" src="https://github.com/user-attachments/assets/499dafe9-7241-4cde-b12e-00cbff0cdefb" />

<img width="1346" alt="스크린샷 2025-07-06 오후 5 22 32" src="https://github.com/user-attachments/assets/4fdc23f3-a1e4-47e4-aee1-b2649ae7549a" />
