### PR TITLE
[EDMT-221] 모바일 뷰에서 헤더 레이아웃 깨지는 현상 수정

### DIFF
--- a/src/app/(record)/layout.tsx
+++ b/src/app/(record)/layout.tsx
@@ -2,15 +2,13 @@ import Header from '@/components/header/header';
 import { SidebarProvider, SidebarTrigger } from '@/components/sidebar/base-sidebar';
 import MainSidebar from '@/components/sidebar/main-sidebar';
 
-export default function RecordLayout({ children }: { children: React.ReactNode }) {
+export default function RecordLayoutClient({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <SidebarProvider>
+      <SidebarTrigger className="fixed left-1 top-[10px] z-50 md:left-2 md:top-[72px]" />
       <Header />
-      <SidebarProvider>
-        <MainSidebar />
-        <SidebarTrigger className="fixed left-2 top-[72px]" />
-        <main className="h-[calc(100vh-64px)] w-full overflow-y-auto p-10">{children}</main>
-      </SidebarProvider>
-    </>
+      <MainSidebar />
+      <main className={`h-[calc(100vh-64px)] w-full overflow-y-auto p-2 md:p-10`}>{children}</main>
+    </SidebarProvider>
   );
 }

--- a/src/components/find-password/find-password.tsx
+++ b/src/components/find-password/find-password.tsx
@@ -22,7 +22,7 @@ export default function FindPassword() {
 
   return (
     <div className="flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-slate-700 px-10 py-16">
-      <h2 className="mb-4 text-[30px] font-bold">비밀번호 변경</h2>
+      <h2 className="mb-4 text-[30px] font-bold">비밀번호 찾기</h2>
 
       {step === 'email' ? (
         <EmailVerificationForm onSuccess={handleEmailSuccess} />

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -38,11 +38,11 @@ export default function Header() {
   }, [open]);
 
   return (
-    <header className="fixed top-0 z-50 flex h-16 w-full justify-between border-b bg-white px-10 py-3">
-      <Link href="/" className="pt-1 text-2xl font-bold text-black">
+    <header className="fixed top-0 z-40 flex h-16 w-full justify-between border-b bg-white px-2 py-3 md:px-10">
+      <Link href="/" className="ml-10 pt-1 text-2xl font-bold text-black md:ml-0">
         EduMate
       </Link>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-1 md:gap-4">
         <a
           href="https://walla.my/survey/tBoiYaly9xugPKLhAyRx"
           target="_blank"

--- a/src/components/mypage/basic-info.tsx
+++ b/src/components/mypage/basic-info.tsx
@@ -42,7 +42,7 @@ export default function BasicInfo({ email }: { email: string }) {
         <div className="flex w-full items-center justify-between gap-7 px-4 py-6">
           <div className="flex gap-7 pt-1">
             <span className="text-slate-500">비밀번호</span>
-            <span className="pt-1 text-lg">********</span>
+            <span className="text-lg text-slate-400">비밀번호를 설정해주세요.</span>
           </div>
           {editMode !== 'email' ? (
             <button

--- a/src/components/record/students-add-button.tsx
+++ b/src/components/record/students-add-button.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import ExcelUploadModal from '@/components/modal/excel-upload-modal';
+import { useAuth } from '@/contexts/auth/use-auth';
 import { useGetRecords } from '@/hooks/api/use-get-records';
 import type { RecordType } from '@/types/api/student-record';
 import { downloadExcel } from '@/util/download-excel';
@@ -12,7 +13,13 @@ export default function StudentAddButton({ recordType }: { recordType: RecordTyp
 
   const { data } = useGetRecords(recordType);
 
+  const { accessToken } = useAuth();
+
   const hasStudents = data && data.students.length > 0;
+
+  if (accessToken === null) {
+    return null;
+  }
 
   const handleDownloadExcel = () => {
     if (hasStudents) {


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-221]

## 🌱 주요 변경 사항
1. 모바일 뷰에서 헤더 레이아웃 깨지는 현상 수정
2. 로그인 상태가 아닐 때 학생 추가 및 엑셀 내보내기 버튼 안보이게 수정

## 📸 스크린샷 (선택)
<img width="587" alt="스크린샷 2025-07-08 오후 3 13 07" src="https://github.com/user-attachments/assets/56392649-4ddf-40e0-b0cc-4831d6ac6e45" />


