### PR TITLE
[EDMT-260] 공지사항 모바일 뷰 대응, mock api 공지사항 수정, 삭제, 추가에 토큰 관리 로직 추가

### DIFF
--- a/src/app/(record)/notice/[id]/page.tsx
+++ b/src/app/(record)/notice/[id]/page.tsx
@@ -16,7 +16,7 @@ export default async function Page({ params }: PageProps) {
   const data = await getNoticeDetail(id);
 
   return (
-    <div className="w-full px-10">
+    <div className="w-full">
       <h2 className="mb-10 text-[26px] font-bold">{data.category}</h2>
       <h3 className="text-[20px] font-bold">{data.title}</h3>
       <span className="text-[14px] text-slate-600">{formatDate(data.createdAt)}</span>

--- a/src/app/(record)/notice/page.tsx
+++ b/src/app/(record)/notice/page.tsx
@@ -22,7 +22,7 @@ export default async function NoticePage({ searchParams }: PageProps) {
   });
 
   return (
-    <div className="h-full w-full px-10">
+    <div className="h-full w-full">
       <h2 className="text-[26px] font-bold">공지사항</h2>
 
       <NoticeCategorys categoryId={categoryId} />

--- a/src/components/notice/notice-list.tsx
+++ b/src/components/notice/notice-list.tsx
@@ -10,11 +10,11 @@ export default function NoticeList({ notice }: { notice: NoticeType[] }) {
         <Link
           key={item.noticeId}
           href={`/notice/${item.noticeId}`}
-          className="flex h-14 items-center align-middle text-black hover:bg-slate-200"
+          className="flex h-14 items-center px-5 align-middle text-black hover:bg-slate-200"
         >
-          <span className="w-40 px-10 font-bold">{item.category}</span>
-          <span>{item.title}</span>
-          <time className="ml-auto w-60 px-5">{formatDate(item.createdAt)}</time>
+          <span className="min-w-12 font-bold">{item.category}</span>
+          <span className="px-4 md:px-10">{item.title}</span>
+          <time className="ml-auto hidden min-w-32 md:block">{formatDate(item.createdAt)}</time>
         </Link>
       ))}
     </div>

--- a/src/mocks/handlers/auth/post-login.ts
+++ b/src/mocks/handlers/auth/post-login.ts
@@ -6,14 +6,30 @@ export const postLogin = [
   http.post('/api/v1/auth/login', async ({ request }) => {
     const { email, password } = (await request.json()) as LoginProp;
 
-    if (email === 'test@naver.com' && password === 'ab1234') {
+    if (email === 'admin@edukit.co.kr' && password === 'password1234') {
       return HttpResponse.json(
         {
           status: 200,
           code: 'EDMT-20002',
           message: '요청에 성공했습니다.',
           data: {
-            accessToken: 'dfnjkadfndask',
+            accessToken: 'admin-access-token',
+            isAdmin: true,
+          },
+        },
+        { status: 200 },
+      );
+    }
+
+    if (email === 'test@edukit.co.kr' && password === 'password1234') {
+      return HttpResponse.json(
+        {
+          status: 200,
+          code: 'EDMT-20002',
+          message: '요청에 성공했습니다.',
+          data: {
+            accessToken: 'user-access-token',
+            isAdmin: false,
           },
         },
         { status: 200 },

--- a/src/mocks/handlers/auth/reissue.ts
+++ b/src/mocks/handlers/auth/reissue.ts
@@ -1,14 +1,34 @@
 import { http, HttpResponse } from 'msw';
 
 export const reissue = [
-  http.patch('/api/v1/auth/reissue', () => {
+  http.patch('/api/v1/auth/reissue', ({ request }) => {
+    const cookieHeader = request.headers.get('cookie');
+
+    let isAdmin = false;
+    let accessToken = 'user-access-token';
+
+    if (cookieHeader?.includes('refreshToken=admin-refresh-token')) {
+      isAdmin = true;
+      accessToken = 'admin-access-token';
+    } else if (cookieHeader?.includes('refreshToken=user-refresh-token')) {
+      isAdmin = false;
+      accessToken = 'user-access-token';
+    } else if (!cookieHeader?.includes('refreshToken=')) {
+      return HttpResponse.json(
+        {
+          status: 401,
+          code: 'EDMT-401',
+          message: '유효하지 않은 리프레시 토큰입니다.',
+        },
+        { status: 401 },
+      );
+    }
+
     return HttpResponse.json({
       status: 200,
       code: 'EDMT-200',
       message: '요청이 성공했습니다.',
-      data: {
-        accessToken: 'new-access-token',
-      },
+      data: { accessToken, isAdmin },
     });
   }),
 ];

--- a/src/mocks/handlers/notice/delete-admin-notice.ts
+++ b/src/mocks/handlers/notice/delete-admin-notice.ts
@@ -1,10 +1,22 @@
 import { http, HttpResponse } from 'msw';
 
 export const deleteAdminNotice = [
-  http.delete('/api/v1/admin/notices:id', async ({ params }) => {
+  http.delete('/api/v1/admin/notices/:noticeId', ({ request, params }) => {
     const { noticeId } = params;
+    const authHeader = request.headers.get('authorization');
 
-    if (noticeId === '10') {
+    if (!authHeader || !authHeader.includes('admin-access-token')) {
+      return HttpResponse.json(
+        {
+          status: 403,
+          code: 'EDMT-403',
+          message: '관리자 권한이 필요합니다.',
+        },
+        { status: 403 },
+      );
+    }
+
+    if (noticeId === '999') {
       return HttpResponse.json(
         {
           status: 404,
@@ -19,6 +31,7 @@ export const deleteAdminNotice = [
       status: 200,
       code: 'EDMT-20000',
       message: '요청이 성공했습니다.',
+      data: null,
     });
   }),
 ];

--- a/src/mocks/handlers/notice/patch-admin-notice.ts
+++ b/src/mocks/handlers/notice/patch-admin-notice.ts
@@ -1,10 +1,39 @@
 import { http, HttpResponse } from 'msw';
 
 export const patchAdminNotice = [
-  http.patch('/api/v1/admin/notices:id', async ({ params }) => {
+  http.patch('/api/v1/admin/notices/:noticeId', async ({ request, params }) => {
     const { noticeId } = params;
+    const authHeader = request.headers.get('authorization');
 
-    if (noticeId === '10') {
+    if (!authHeader || !authHeader.includes('admin-access-token')) {
+      return HttpResponse.json(
+        {
+          status: 403,
+          code: 'EDMT-403',
+          message: '관리자 권한이 필요합니다.',
+        },
+        { status: 403 },
+      );
+    }
+
+    const body = (await request.json()) as {
+      categoryId: number;
+      title: string;
+      content: string;
+    };
+
+    if (!body.title?.trim() || !body.content?.trim()) {
+      return HttpResponse.json(
+        {
+          status: 400,
+          code: 'EDMT-400',
+          message: '제목과 내용을 모두 입력해주세요.',
+        },
+        { status: 400 },
+      );
+    }
+
+    if (noticeId === '999') {
       return HttpResponse.json(
         {
           status: 404,
@@ -19,6 +48,7 @@ export const patchAdminNotice = [
       status: 200,
       code: 'EDMT-20000',
       message: '요청이 성공했습니다.',
+      data: null,
     });
   }),
 ];

--- a/src/mocks/handlers/notice/post-admin-notice.ts
+++ b/src/mocks/handlers/notice/post-admin-notice.ts
@@ -4,7 +4,31 @@ import type { AdminNoticeRequest } from '@/types/api/notice';
 
 export const postAdminNotice = [
   http.post('/api/v1/admin/notices', async ({ request }) => {
+    const authHeader = request.headers.get('authorization');
+
+    if (!authHeader || !authHeader.includes('admin-access-token')) {
+      return HttpResponse.json(
+        {
+          status: 403,
+          code: 'EDMT-403',
+          message: '관리자 권한이 필요합니다.',
+        },
+        { status: 403 },
+      );
+    }
+
     const body = (await request.json()) as AdminNoticeRequest;
+
+    if (!body.title?.trim() || !body.content?.trim()) {
+      return HttpResponse.json(
+        {
+          status: 400,
+          code: 'EDMT-400',
+          message: '제목과 내용을 모두 입력해주세요.',
+        },
+        { status: 400 },
+      );
+    }
 
     if (body.categoryId !== 2 && body.categoryId !== 3) {
       return HttpResponse.json(
@@ -21,6 +45,7 @@ export const postAdminNotice = [
       status: 200,
       code: 'EDMT-20000',
       message: '요청이 성공했습니다.',
+      data: null,
     });
   }),
 ];


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-260]

## 🌱 주요 변경 사항

1. 공지사항 모바일 뷰 대응
2. mock api 공지사항 수정, 삭제, 추가에 토큰 관리 로직 추가
3. 로그인 mock api에 관리자, 일반 유저 검증 로직 추가 및 reissue 리프레쉬 토큰으로 accessToken을 받아오는 로직 추가

## 📸 스크린샷 (선택)
<img width="510" height="773" alt="스크린샷 2025-07-12 오후 11 21 34" src="https://github.com/user-attachments/assets/37fe108e-b6a9-46a4-91dd-2caa33a4f1a9" />


[EDMT-260]: https://bbangbbangz.atlassian.net/browse/EDMT-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 공지사항 상세 및 목록 페이지의 패딩과 레이아웃이 조정되어, 콘텐츠의 가로 여백과 반응형 정렬이 개선되었습니다.

* **Bug Fixes**
  * 관리자 공지사항 삭제 및 수정, 등록 시 경로 및 인증/입력값 검증 로직이 강화되어, 올바르지 않은 접근이나 데이터 누락 시 명확한 에러 메시지가 제공됩니다.
  * 토큰 재발급 및 로그인 시 관리자/일반 사용자 구분이 명확하게 처리되어, 권한에 따라 적절한 응답이 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->