### PR TITLE
[EDMT-362] 공지사항 작성 및 수정 기능에 presigned-url 로직 추가

### DIFF
--- a/src/domains/notice/__tests__/notice-admin.integration.test.tsx
+++ b/src/domains/notice/__tests__/notice-admin.integration.test.tsx
@@ -40,6 +40,7 @@ const mockNoticeDetail: DetailNoticeResponse = {
   content: '<p>테스트 내용입니다.</p>',
   category: '공지',
   createdAt: '2024-01-01T00:00:00Z',
+  noticeFileKeys: ['1', '2', '3'],
 };
 
 describe('notice-admin 기능 통합 테스트', () => {

--- a/src/domains/notice/apis/get-presigned-url.ts
+++ b/src/domains/notice/apis/get-presigned-url.ts
@@ -1,0 +1,85 @@
+import type { PresignedUrlResponse, ImageUploadData } from '@/domains/notice/types/notice';
+import { api } from '@/shared/lib/api';
+
+// presigned url을 받는 api로직
+export const getPresignedUrl = async (filenames: string[]): Promise<PresignedUrlResponse> => {
+  const filenamesParam = filenames.join(',');
+  return api.get<PresignedUrlResponse>(
+    `/api/v2/admin/notices/presigned-url?filenames=${encodeURIComponent(filenamesParam)}`,
+  );
+};
+
+// S3에 파일을 업로드하는 api 로직
+export const uploadToS3 = async (presignedUrl: string, file: File): Promise<void> => {
+  const response = await fetch(presignedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`S3 업로드 실패: ${response.status} ${response.statusText}`);
+  }
+};
+
+/**
+ * 여러 이미지를 한 번에 업로드하는 함수
+ * 1. 모든 파일에 대해 한 번의 API 호출로 presigned URL들을 받아옴
+ * 2. 각 파일을 해당하는 presigned URL로 S3에 업로드
+ */
+export const uploadMultipleImagesToS3 = async (files: File[]): Promise<ImageUploadData[]> => {
+  // 1. 파일 검증
+  for (const file of files) {
+    if (file.size > 5 * 1024 * 1024) {
+      throw new Error(`파일 "${file.name}"의 크기가 5MB를 초과합니다.`);
+    }
+
+    const supportedTypes = ['image/png', 'image/jpg', 'image/jpeg', 'image/gif', 'image/webp'];
+    if (!supportedTypes.includes(file.type)) {
+      throw new Error(
+        `파일 "${file.name}"은 지원하지 않는 형식입니다. (png, jpg, jpeg, gif, webp만 지원)`,
+      );
+    }
+  }
+
+  // 2. 모든 파일명 추출
+  const filenames = files.map((file) => file.name);
+
+  // 3. API 호출로 모든 presigned URL 받아오기
+  const response = await getPresignedUrl(filenames);
+  const imageDataArray = response.images;
+
+  // 4. 각 파일을 해당하는 presigned URL로 S3에 병렬 업로드
+  const uploadPromises = files.map(async (file, index) => {
+    const imageData = imageDataArray[index];
+    try {
+      await uploadToS3(imageData.uploadPresignedUrl, file);
+      return imageData;
+    } catch (error) {
+      throw new Error(
+        `파일 "${file.name}" 업로드 실패: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+      );
+    }
+  });
+
+  return Promise.all(uploadPromises);
+};
+
+// 고유한 파일명을 만드는 헬퍼 함수
+export const generateUniqueFilename = (filename: string): string => {
+  const extension = filename.split('.').pop()?.toLowerCase() || '';
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 15);
+  return `${timestamp}-${random}.${extension}`;
+};
+
+export const uploadMultipleImages = async (files: File[]): Promise<ImageUploadData[]> => {
+  const renamedFiles = files.map((file) => {
+    const uniqueFilename = generateUniqueFilename(file.name);
+    return new File([file], uniqueFilename, { type: file.type });
+  });
+
+  return uploadMultipleImagesToS3(renamedFiles);
+};

--- a/src/domains/notice/apis/mutations/use-patch-admin-notice.ts
+++ b/src/domains/notice/apis/mutations/use-patch-admin-notice.ts
@@ -9,11 +9,13 @@ export const patchAdminNotice = async ({
   category,
   title,
   content,
+  fileKeys,
 }: EditAdminNoticeRequest) => {
   return api.patch<ApiResponseWithoutData>(`/api/v2/admin/notices/${noticeId}`, {
     category,
     title,
     content,
+    fileKeys,
   });
 };
 

--- a/src/domains/notice/apis/mutations/use-post-admin-notice.ts
+++ b/src/domains/notice/apis/mutations/use-post-admin-notice.ts
@@ -4,11 +4,12 @@ import type { AdminNoticeBody } from '@/domains/notice/types/notice';
 import { api } from '@/shared/lib/api';
 import type { ApiResponseWithoutData } from '@/shared/types/response';
 
-export const postAdminNotice = async ({ category, title, content }: AdminNoticeBody) => {
+export const postAdminNotice = async ({ category, title, content, fileKeys }: AdminNoticeBody) => {
   return api.post<ApiResponseWithoutData>('/api/v2/admin/notices', {
     category,
     title,
     content,
+    fileKeys,
   });
 };
 

--- a/src/domains/notice/components/edit-notice.tsx
+++ b/src/domains/notice/components/edit-notice.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { usePatchAdminNotice } from '@/domains/notice/apis/mutations/use-patch-admin-notice';
+import { useNoticeFileKeys } from '@/domains/notice/hooks/use-notice-file-keys';
 import type { DetailNoticeResponse, NoticeCategoryType } from '@/domains/notice/types/notice';
 import TipTapEditor, { type TipTapEditorRef } from '@/shared/components/ui/editor/tiptap-editor';
 import { Input } from '@/shared/components/ui/input/input';
@@ -30,28 +31,41 @@ export default function EditNotice({ notice }: EditNoticeProps) {
   const titleRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<TipTapEditorRef>(null);
 
+  const { handleImageUpload, extractUsedFileKeys, convertTmpUrlsToFileUrls } = useNoticeFileKeys({
+    existingFileKeys: notice.noticeFileKeys || [],
+    existingContent: notice.content || '',
+  });
+
   const { mutate: patchAdminNotice } = usePatchAdminNotice();
 
   const handleSubmit = () => {
     const title = titleRef.current?.value;
-    const content = editorRef.current?.getHTML();
+    const rawContent = editorRef.current?.getHTML();
 
-    if (!title?.trim() || !content?.replace(/<[^>]*>/g, '').trim()) {
+    if (!title?.trim() || !rawContent?.replace(/<[^>]*>/g, '').trim()) {
       alert('제목과 내용을 모두 입력해주세요.');
       return;
     }
+
+    const convertedContent = convertTmpUrlsToFileUrls(rawContent);
+
+    const fileKeys = extractUsedFileKeys(rawContent);
 
     patchAdminNotice(
       {
         noticeId: notice.noticeId,
         title,
-        content,
+        content: convertedContent,
         category: selectedTag,
+        fileKeys,
       },
       {
         onSuccess: async () => {
           await revalidateNotice(notice.noticeId);
           router.push(`/notice/${notice.noticeId}`);
+        },
+        onError: () => {
+          alert('공지사항 수정에 실패했습니다. 다시 시도해주세요.');
         },
       },
     );
@@ -88,6 +102,7 @@ export default function EditNotice({ notice }: EditNoticeProps) {
         initialContent={notice?.content || ''}
         placeholder="내용을 입력해주세요."
         className="w-full max-w-4xl"
+        onImageUpload={handleImageUpload}
       />
 
       <div className="flex gap-4">

--- a/src/domains/notice/components/edit-notice.tsx
+++ b/src/domains/notice/components/edit-notice.tsx
@@ -64,9 +64,6 @@ export default function EditNotice({ notice }: EditNoticeProps) {
           await revalidateNotice(notice.noticeId);
           router.push(`/notice/${notice.noticeId}`);
         },
-        onError: () => {
-          alert('공지사항 수정에 실패했습니다. 다시 시도해주세요.');
-        },
       },
     );
   };

--- a/src/domains/notice/components/write-notice.tsx
+++ b/src/domains/notice/components/write-notice.tsx
@@ -47,9 +47,6 @@ export default function WriteNotice() {
           await revalidateNotice();
           router.push('/notice');
         },
-        onError: () => {
-          alert('공지사항 작성에 실패했습니다. 다시 시도해주세요.');
-        },
       },
     );
   };

--- a/src/domains/notice/components/write-notice.tsx
+++ b/src/domains/notice/components/write-notice.tsx
@@ -5,16 +5,11 @@ import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { usePostAdminNotice } from '@/domains/notice/apis/mutations/use-post-admin-notice';
-import { type NoticeCategoryType } from '@/domains/notice/types/notice';
+import { useNoticeFileKeys } from '@/domains/notice/hooks/use-notice-file-keys';
+import type { NoticeCategoryType } from '@/domains/notice/types/notice';
 import TipTapEditor, { type TipTapEditorRef } from '@/shared/components/ui/editor/tiptap-editor';
 import { Input } from '@/shared/components/ui/input/input';
 import { revalidateNotice } from '@/shared/lib/actions/revalidateNotice';
-
-const baseStyle = 'rounded-full px-5 py-1 pt-1.5 text-center font-bold text-[14px]';
-
-const activeStyle = 'bg-slate-800 text-white border border-white';
-
-const nonActiveStyle = 'bg-white text-black border border-slate-400';
 
 export default function WriteNotice() {
   const router = useRouter();
@@ -23,22 +18,37 @@ export default function WriteNotice() {
   const titleRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<TipTapEditorRef>(null);
 
-  const { mutate: postAdminNotice } = usePostAdminNotice();
+  const { mutate: postAdminNotice, isPending } = usePostAdminNotice();
+
+  const { handleImageUpload, extractUsedFileKeys, convertTmpUrlsToFileUrls } = useNoticeFileKeys();
 
   const handleSubmit = () => {
     const title = titleRef.current?.value;
-    const content = contentRef.current?.getHTML();
-    if (!title?.trim() || !content?.replace(/<[^>]*>/g, '').trim()) {
+    const rawContent = contentRef.current?.getHTML();
+
+    if (!title?.trim() || !rawContent?.replace(/<[^>]*>/g, '').trim()) {
       alert('제목과 내용을 모두 입력해주세요.');
       return;
     }
 
+    const convertedContent = convertTmpUrlsToFileUrls(rawContent);
+
+    const fileKeys = extractUsedFileKeys(rawContent);
+
     postAdminNotice(
-      { title, content, category: selectedTag },
+      {
+        title,
+        content: convertedContent,
+        category: selectedTag,
+        fileKeys,
+      },
       {
         onSuccess: async () => {
           await revalidateNotice();
           router.push('/notice');
+        },
+        onError: () => {
+          alert('공지사항 작성에 실패했습니다. 다시 시도해주세요.');
         },
       },
     );
@@ -49,29 +59,43 @@ export default function WriteNotice() {
       <div className="flex gap-4">
         <button
           onClick={() => isSelectedTag('announcement')}
-          className={`${baseStyle} ${selectedTag === 'announcement' ? activeStyle : nonActiveStyle}`}
+          className={`rounded-full px-5 py-1 pt-1.5 text-center text-[14px] font-bold ${
+            selectedTag === 'announcement'
+              ? 'border border-white bg-slate-800 text-white'
+              : 'border border-slate-400 bg-white text-black'
+          }`}
         >
           공지
         </button>
         <button
           onClick={() => isSelectedTag('event')}
-          className={`${baseStyle} ${selectedTag === 'event' ? activeStyle : nonActiveStyle}`}
+          className={`rounded-full px-5 py-1 pt-1.5 text-center text-[14px] font-bold ${
+            selectedTag === 'event'
+              ? 'border border-white bg-slate-800 text-white'
+              : 'border border-slate-400 bg-white text-black'
+          }`}
         >
           이벤트
         </button>
       </div>
+
       <Input ref={titleRef} placeholder="제목" />
 
       <TipTapEditor
         ref={contentRef}
         placeholder="내용을 입력해주세요."
         className="w-full max-w-4xl"
+        onImageUpload={handleImageUpload}
       />
+
       <button
         onClick={handleSubmit}
-        className="rounded-md bg-slate-800 px-4 py-2 text-white hover:bg-slate-950"
+        disabled={isPending}
+        className={`rounded-md px-4 py-2 text-white transition-colors ${
+          isPending ? 'cursor-not-allowed bg-slate-400' : 'bg-slate-800 hover:bg-slate-950'
+        }`}
       >
-        작성하기
+        {isPending ? '작성 중...' : '작성하기'}
       </button>
     </div>
   );

--- a/src/domains/notice/hooks/use-notice-file-keys.ts
+++ b/src/domains/notice/hooks/use-notice-file-keys.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react';
+
+import type { UploadedImageInfo } from '@/domains/notice/types/notice';
+
+interface UseNoticeFileKeysProps {
+  existingFileKeys?: string[];
+  existingContent?: string;
+}
+
+export const useNoticeFileKeys = ({
+  existingFileKeys = [],
+  existingContent = '',
+}: UseNoticeFileKeysProps = {}) => {
+  const [uploadedImages, setUploadedImages] = useState<UploadedImageInfo[]>([]);
+
+  const [existingImageMap, setExistingImageMap] = useState<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    if (existingFileKeys.length > 0 && existingContent) {
+      const imageMap = new Map<string, string>();
+
+      existingFileKeys.forEach((fileKey) => {
+        const fileUrl = `https://dev-cdn.edukit.co.kr/${fileKey}`;
+        if (existingContent.includes(fileUrl)) {
+          imageMap.set(fileKey, fileUrl);
+        }
+      });
+
+      setExistingImageMap(imageMap);
+    }
+  }, [existingFileKeys, existingContent]);
+
+  const handleImageUpload = (imageInfo: UploadedImageInfo) => {
+    setUploadedImages((prev) => [...prev, imageInfo]);
+  };
+
+  const extractUsedFileKeys = (htmlContent: string): string[] => {
+    const usedFileKeys: string[] = [];
+
+    uploadedImages.forEach(({ tmpFileUrl, fileKey }) => {
+      if (htmlContent.includes(tmpFileUrl)) {
+        usedFileKeys.push(fileKey);
+      }
+    });
+
+    existingImageMap.forEach((fileUrl, fileKey) => {
+      if (htmlContent.includes(fileUrl)) {
+        usedFileKeys.push(fileKey);
+      }
+    });
+
+    return usedFileKeys;
+  };
+
+  const convertTmpUrlsToFileUrls = (htmlContent: string): string => {
+    let convertedContent = htmlContent;
+
+    uploadedImages.forEach(({ tmpFileUrl, fileUrl }) => {
+      if (convertedContent.includes(tmpFileUrl)) {
+        convertedContent = convertedContent.replace(new RegExp(tmpFileUrl, 'g'), fileUrl);
+      }
+    });
+
+    return convertedContent;
+  };
+
+  const resetFileKeys = () => {
+    setUploadedImages([]);
+    setExistingImageMap(new Map());
+  };
+
+  return {
+    handleImageUpload,
+    extractUsedFileKeys,
+    convertTmpUrlsToFileUrls,
+    resetFileKeys,
+
+    uploadedImagesCount: uploadedImages.length,
+    existingImagesCount: existingImageMap.size,
+    totalImagesCount: uploadedImages.length + existingImageMap.size,
+  };
+};

--- a/src/domains/notice/hooks/use-notice-file-keys.ts
+++ b/src/domains/notice/hooks/use-notice-file-keys.ts
@@ -57,7 +57,7 @@ export const useNoticeFileKeys = ({
 
     uploadedImages.forEach(({ tmpFileUrl, fileUrl }) => {
       if (convertedContent.includes(tmpFileUrl)) {
-        convertedContent = convertedContent.replace(new RegExp(tmpFileUrl, 'g'), fileUrl);
+        convertedContent = convertedContent.replaceAll(tmpFileUrl, fileUrl);
       }
     });
 

--- a/src/domains/notice/mocks/get-notice-detail.ts
+++ b/src/domains/notice/mocks/get-notice-detail.ts
@@ -14,6 +14,7 @@ const notices: DetailNoticeResponse[] = Array.from({ length: 80 }, (_, i) => {
     title: `공지사항 제목 ${i + 1}`,
     createdAt: new Date(Date.now() - i * 1000 * 60 * 60).toISOString(),
     content,
+    noticeFileKeys: ['1', '2', '3'],
   };
 });
 

--- a/src/domains/notice/types/notice.ts
+++ b/src/domains/notice/types/notice.ts
@@ -21,14 +21,34 @@ export interface NoticeListResponse {
 
 export interface DetailNoticeResponse extends Notice {
   content: string;
+  noticeFileKeys: string[];
 }
 
 export interface AdminNoticeBody {
-  category: string;
+  category: NoticeCategoryType;
   title: string;
   content: string;
+  fileKeys?: string[];
 }
 
 export interface EditAdminNoticeRequest extends AdminNoticeBody {
   noticeId: number;
+  fileKeys?: string[];
+}
+
+export interface ImageUploadData {
+  uploadPresignedUrl: string;
+  tmpFileUrl: string;
+  fileUrl: string;
+  fileKey: string;
+}
+
+export interface PresignedUrlResponse {
+  images: ImageUploadData[];
+}
+
+export interface UploadedImageInfo {
+  tmpFileUrl: string;
+  fileUrl: string;
+  fileKey: string;
 }

--- a/src/shared/components/ui/editor/tiptap-editor.tsx
+++ b/src/shared/components/ui/editor/tiptap-editor.tsx
@@ -14,6 +14,9 @@ import TextStyle from '@tiptap/extension-text-style';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 
+import { uploadMultipleImages } from '@/domains/notice/apis/get-presigned-url';
+import { type UploadedImageInfo } from '@/domains/notice/types/notice';
+
 export interface TipTapEditorRef {
   getContent: () => string;
   setContent: (content: string) => void;
@@ -47,25 +50,90 @@ interface TipTapEditorProps {
   placeholder?: string;
   className?: string;
   initialContent?: string;
-  onContentChange?: (content: string) => void;
+  onImageUpload?: (imageInfo: UploadedImageInfo) => void;
 }
 
 const TipTapEditor = forwardRef<TipTapEditorRef, TipTapEditorProps>(
   (
-    { placeholder = '내용을 입력해주세요.', className = '', initialContent = '', onContentChange },
+    { placeholder = '내용을 입력해주세요.', className = '', initialContent = '', onImageUpload },
     ref,
   ) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleMultipleImageUploadAndInsert = async (files: File[]): Promise<void> => {
+      if (files.length === 0) return;
+
+      try {
+        const uploadResults = await uploadMultipleImages(files);
+
+        uploadResults.forEach((result, index) => {
+          if (onImageUpload) {
+            onImageUpload({
+              tmpFileUrl: result.tmpFileUrl,
+              fileUrl: result.fileUrl,
+              fileKey: result.fileKey,
+            });
+          }
+
+          setTimeout(() => {
+            editor?.commands.setImage({ src: result.tmpFileUrl });
+
+            if (index < uploadResults.length - 1) {
+              editor?.commands.createParagraphNear();
+            }
+          }, index * 100);
+        });
+      } catch (error) {
+        alert(
+          error instanceof Error
+            ? error.message
+            : '이미지 업로드에 실패했습니다. 다시 시도해주세요.',
+        );
+      }
+    };
+
+    const convertToFileArray = (fileList: FileList | File[]): File[] => {
+      if (Array.isArray(fileList)) {
+        return fileList;
+      }
+      return Array.from(fileList);
+    };
+
+    const filterImageFiles = (files: File[]): File[] => {
+      return files.filter((file) => file.type.startsWith('image/'));
+    };
+
+    const extractImageFilesFromClipboard = async (clipboardData: DataTransfer): Promise<File[]> => {
+      const files: File[] = [];
+
+      if (clipboardData.files && clipboardData.files.length > 0) {
+        const fileArray = convertToFileArray(clipboardData.files);
+        const imageFiles = filterImageFiles(fileArray);
+        files.push(...imageFiles);
+      }
+
+      for (let i = 0; i < clipboardData.items.length; i++) {
+        const item = clipboardData.items[i];
+
+        if (item.type.startsWith('image/')) {
+          const blob = item.getAsFile();
+          if (blob) {
+            const file = new File([blob], `pasted-image-${Date.now()}.${item.type.split('/')[1]}`, {
+              type: item.type,
+            });
+            files.push(file);
+          }
+        }
+      }
+
+      return files;
+    };
 
     const editor = useEditor({
       extensions: [
         StarterKit,
         Image.configure({
-          HTMLAttributes: {
-            class:
-              'max-w-full h-auto rounded-lg cursor-pointer border-2 border-transparent hover:border-blue-300 transition-colors',
-          },
-          allowBase64: true,
+          allowBase64: false,
         }),
         Table.configure({
           resizable: true,
@@ -104,11 +172,42 @@ const TipTapEditor = forwardRef<TipTapEditorRef, TipTapEditorProps>(
           class:
             'prose prose-sm sm:prose-base lg:prose-lg xl:prose-2xl mx-auto focus:outline-none min-h-[300px] p-4',
         },
-      },
-      onUpdate: ({ editor }) => {
-        if (onContentChange) {
-          onContentChange(editor.getHTML());
-        }
+        handleDrop(view, event, slice, moved) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (
+            !moved &&
+            event.dataTransfer &&
+            event.dataTransfer.files &&
+            event.dataTransfer.files.length > 0
+          ) {
+            const files = convertToFileArray(event.dataTransfer.files);
+            const imageFiles = filterImageFiles(files);
+
+            if (imageFiles.length > 0) {
+              handleMultipleImageUploadAndInsert(imageFiles);
+              return true;
+            }
+          }
+
+          return false;
+        },
+        handlePaste(view, event, slice) {
+          if (!event.clipboardData) {
+            return false;
+          }
+
+          extractImageFilesFromClipboard(event.clipboardData).then((imageFiles) => {
+            if (imageFiles.length > 0) {
+              event.preventDefault();
+              event.stopPropagation();
+              handleMultipleImageUploadAndInsert(imageFiles);
+            }
+          });
+
+          return false;
+        },
       },
       immediatelyRender: false,
     });
@@ -129,20 +228,19 @@ const TipTapEditor = forwardRef<TipTapEditorRef, TipTapEditorProps>(
       fileInputRef.current?.click();
     };
 
-    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (file) {
-        if (file.size > 5 * 1024 * 1024) {
-          alert('이미지 크기는 5MB를 초과할 수 없습니다.');
-          return;
+    const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const fileList = event.target.files;
+      if (fileList && fileList.length > 0) {
+        const files = convertToFileArray(fileList);
+        const imageFiles = filterImageFiles(files);
+
+        if (imageFiles.length > 0) {
+          await handleMultipleImageUploadAndInsert(imageFiles);
+        } else {
+          alert('이미지 파일만 업로드할 수 있습니다.');
         }
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          const src = e.target?.result as string;
-          editor?.commands.setImage({ src });
-        };
-        reader.readAsDataURL(file);
       }
+
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
       }
@@ -263,16 +361,17 @@ const TipTapEditor = forwardRef<TipTapEditorRef, TipTapEditorProps>(
           </ToolbarButton>
         </div>
 
-        <div className="min-h-[300px]">
+        <div className="relative min-h-[300px]">
           <EditorContent editor={editor} className="h-full" placeholder={placeholder} />
         </div>
 
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/*"
+          accept="image/png,image/jpg,image/jpeg,image/gif,image/webp"
           onChange={handleFileChange}
           className="hidden"
+          multiple
         />
       </div>
     );


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-362]

## 🌱 주요 변경 사항

1. presigned-url api 구현
2. 에디터에서 이미지 드래그앤 드롭 기능 구현 및 presigned-url api 연동
3. 공지사항 admin 기능 api 명세 변경에 따른 타입 리팩토링 및 presigned-url에 필요한 타입 추가
4. 공지사항 어드민 기능 작성 및 수정 api 로직에 fileKey 추가
5. 공지사항 작성 및 수정하기 버튼 누를때 content파싱해서 이미지 경로에서 fileKey 추출하는 커스텀 훅 구현
6. 공지사항 작성 및 수정 컴포넌트에 fileKey 추출하는 로직 연동


[EDMT-362]: https://bbangbbangz.atlassian.net/browse/EDMT-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 공지 작성/수정에서 다중 이미지 업로드(프리사인드 URL 사용) 및 에디터 즉시 삽입(드래그·붙여넣기·파일 선택) 지원.
  - 에디터에 이미지 업로드 콜백과 콘텐츠 추출 기능 추가로 임시 URL을 최종 CDN URL로 변환.

- 개선
  - 작성/수정 요청에 첨부 파일 키(fileKeys) 포함으로 이미지 연동이 명확해짐.
  - 제출 중 버튼 로딩/비활성화 및 업로드 실패 시 사용자 알림 강화.

- 테스트
  - 공지 상세 목(mock) 데이터에 파일 키 추가로 시나리오 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->