### PR TITLE
[EDMT-393] 디자인된 헤더 반영

### DIFF
--- a/src/app/(main)/(record)/manage-student/page.tsx
+++ b/src/app/(main)/(record)/manage-student/page.tsx
@@ -1,0 +1,8 @@
+import FreeRecordTable from '@/domains/record/components/student-manage/free-record-table';
+import { createPageMetadata } from '@/shared/constants/metadata';
+
+export const metadata = createPageMetadata('manageStudent', { url: '/manage-free' });
+
+export default function Page() {
+  return <FreeRecordTable />;
+}

--- a/src/shared/components/layout/header/header.tsx
+++ b/src/shared/components/layout/header/header.tsx
@@ -29,8 +29,9 @@ export default function Header() {
   const isLogIn = !!accessToken;
 
   const isActiveTab = (tabPath: string) => {
-    if (tabPath === '/ai-record') {
+    if (tabPath === '/manage-student') {
       const recordPaths = [
+        '/manage-student',
         '/manage-subject',
         '/manage-behavior',
         '/manage-career',

--- a/src/shared/components/layout/header/header.tsx
+++ b/src/shared/components/layout/header/header.tsx
@@ -4,18 +4,48 @@ import { useEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { ProfileDropDown } from '@/domains/profile/components/profile-dropdown';
 import { useAuth } from '@/shared/providers/auth-provider';
 
 import ProfileImage from '../../../../../public/images/profile-image.png';
+import Logo from '../../../../../public/svgs/logo.svg';
+
+const tabStyle = 'flex pt-6 mx-5 flex-col justify-between items-center whitespace-nowrap';
+
+const tabs = [
+  { label: 'AI 생활기록부 작성', path: '/manage-student' },
+  { label: '커뮤니티', path: '/' },
+  { label: '공지사항', path: '/notice' },
+];
 
 export default function Header() {
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { accessToken } = useAuth();
+  const pathname = usePathname();
 
   const isLogIn = !!accessToken;
+
+  const isActiveTab = (tabPath: string) => {
+    if (tabPath === '/ai-record') {
+      const recordPaths = [
+        '/manage-subject',
+        '/manage-behavior',
+        '/manage-career',
+        '/manage-free',
+        '/manage-club',
+        '/write-subject',
+        '/write-behavior',
+        '/write-career',
+        '/write-free',
+        '/write-club',
+      ];
+      return recordPaths.some((path) => pathname === path || pathname.startsWith(path + '/'));
+    }
+    return pathname === tabPath || pathname.startsWith(tabPath + '/');
+  };
 
   const handleCloseDropdown = () => {
     setOpen(false);
@@ -38,43 +68,75 @@ export default function Header() {
   }, [open]);
 
   return (
-    <header className="fixed top-0 z-30 flex h-16 w-full justify-between border-b bg-white px-2 py-3 md:px-10">
-      <Link href="/" className="ml-10 pt-1 text-2xl font-bold text-black md:ml-0">
-        Edukit
-      </Link>
-      <div className="flex items-center gap-1 md:gap-4">
-        <a
-          href="https://walla.my/survey/tBoiYaly9xugPKLhAyRx"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="rounded-full bg-blue-600 px-4 py-2 text-white hover:bg-blue-800"
-        >
-          피드백 작성하기
-        </a>
-        <div className="relative">
-          {isLogIn ? (
-            <>
-              <Image
-                src={ProfileImage}
-                alt="profile image"
-                className="hover:cursor-pointer"
-                onClick={() => setOpen((prev) => !prev)}
-                width={40}
-              />
-              {open ? (
-                <div ref={dropdownRef}>
-                  <ProfileDropDown onClose={handleCloseDropdown} />
-                </div>
-              ) : null}
-            </>
-          ) : (
-            <Link
-              href="/login"
-              className="flex h-10 items-center justify-center rounded-full bg-black px-6 text-white"
-            >
-              로그인
-            </Link>
-          )}
+    <header className="fixed top-0 z-30 flex h-[72px] w-full justify-center border-b border-b-gray-2 bg-white">
+      <div className="flex w-[1440px] justify-between px-10">
+        <div className="flex gap-4 lg:gap-40">
+          <Link href="/" className="flex items-center">
+            <Image
+              src={Logo}
+              alt="logo"
+              width={126}
+              height={28}
+              className="h-[28px] w-[126px] object-contain"
+            />
+          </Link>
+          <div className="flex">
+            {tabs.map((tab, index) => {
+              const isActive = isActiveTab(tab.path);
+
+              return (
+                <Link key={tab.path} href={tab.path} className={`${tabStyle} gap-1`}>
+                  {index === 0 ? (
+                    <div className="flex gap-1">
+                      <span className="text-heading-18 text-blue-400">AI</span>
+                      <span className="mt-[2px] text-label-18">생활기록부 작성</span>
+                    </div>
+                  ) : (
+                    <span className="mt-[2px] text-label-18">{tab.label}</span>
+                  )}
+
+                  {isActive ? <div className="h-1 w-full bg-black" /> : null}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 md:gap-4">
+          <a
+            href="https://walla.my/survey/tBoiYaly9xugPKLhAyRx"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="whitespace-nowrap rounded-full bg-blue-600 px-4 py-2 text-white hover:bg-blue-800"
+          >
+            피드백 작성하기
+          </a>
+          <div className="relative">
+            {isLogIn ? (
+              <>
+                <Image
+                  src={ProfileImage}
+                  alt="profile image"
+                  onClick={() => setOpen((prev) => !prev)}
+                  width={48}
+                  height={48}
+                  className="h-[48px] w-[48px] rounded-full object-cover hover:cursor-pointer"
+                />
+                {open ? (
+                  <div ref={dropdownRef}>
+                    <ProfileDropDown onClose={handleCloseDropdown} />
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <Link
+                href="/login"
+                className="flex h-10 items-center justify-center whitespace-nowrap rounded-full bg-black px-6 text-white"
+              >
+                로그인
+              </Link>
+            )}
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-393]

## 🌱 주요 변경 사항

1. 헤더 반영
2. 학생 관리 페이지 추가(수정 필요)

## 📸 스크린샷 (선택)

<img width="1710" height="73" alt="스크린샷 2025-08-25 오후 3 19 29" src="https://github.com/user-attachments/assets/71cd347d-1b1a-4f49-8ded-13e21aaa21be" />


[EDMT-393]: https://bbangbbangz.atlassian.net/browse/EDMT-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - “AI 생활기록부 관리” 페이지 추가: 학생 자유 기록을 한눈에 관리할 수 있는 전용 화면이 새로 생겼습니다.
- 스타일
  - 헤더 전면 개편: 로고 중심 레이아웃, 3개 탭 내비게이션(활성 상태 표시), 우측 피드백 링크 및 로그인/프로필 드롭다운 제공.
  - 로그인 시 프로필 이미지로 드롭다운 접근, 비로그인 시 로그인 버튼 표시.
  - 드롭다운 바깥 클릭 시 자동 닫힘 등 상호작용 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->