### PR TITLE
[EDMT-392] 프로필 api 명세 변경에 따른 수정, 회원 탈퇴 로직 추가

### DIFF
--- a/scripts/generate-msw.ts
+++ b/scripts/generate-msw.ts
@@ -72,8 +72,60 @@ export const ${handlerName} = [
   return template;
 }
 
-// 파일 경로를 도메인과 상대 경로로 분리
+// 새 핸들러를 기존 handlers.ts에 추가
+function addToHandlersFile(domain: string, fileName: string) {
+  const projectRoot = process.cwd();
+  const handlersPath = path.join(projectRoot, 'src', 'shared', 'mocks', 'handlers.ts');
 
+  const exportName = toCamelCase(fileName);
+  const importPath = `../../domains/${domain}/mocks/${fileName}`;
+  const newImport = `import { ${exportName} } from '${importPath}';`;
+  const newHandler = `...${exportName}`;
+
+  // 기존 파일 읽기
+  let content = fs.readFileSync(handlersPath, 'utf-8');
+
+  // import 구문 추가 (마지막 import 다음에)
+  const lastImportMatch = content.match(/^import.*$/gm);
+  if (lastImportMatch) {
+    const lastImportIndex = content.lastIndexOf(lastImportMatch[lastImportMatch.length - 1]);
+    const afterLastImport = lastImportIndex + lastImportMatch[lastImportMatch.length - 1].length;
+    content = content.slice(0, afterLastImport) + `\n${newImport}` + content.slice(afterLastImport);
+  } else {
+    // import가 없으면 파일 맨 위에 추가
+    content = `${newImport}\n\n${content}`;
+  }
+
+  // handlers 배열에 추가 (마지막 항목 뒤에)
+  const handlersMatch = content.match(/export const handlers = \[([\s\S]*?)\];/);
+  if (handlersMatch) {
+    const handlersContent = handlersMatch[1].trim();
+    let newHandlersContent;
+
+    if (handlersContent) {
+      // 기존 핸들러들이 있으면 끝에 추가
+      newHandlersContent = `${handlersContent}\n  ${newHandler}`;
+    } else {
+      // 빈 배열이면 첫 번째로 추가
+      newHandlersContent = `\n  ${newHandler},`;
+    }
+
+    content = content.replace(
+      /export const handlers = \[([\s\S]*?)\];/,
+      `export const handlers = [${newHandlersContent},\n];`,
+    );
+  }
+
+  // 파일 저장
+  fs.writeFileSync(handlersPath, content);
+}
+
+// 카멜케이스로 변환
+function toCamelCase(str: string): string {
+  return str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+}
+
+// 파일 경로를 도메인과 상대 경로로 분리
 function parseFilePath(inputPath: string): { domain: string; fileName: string } {
   const parts = inputPath.split('/');
 
@@ -82,7 +134,11 @@ function parseFilePath(inputPath: string): { domain: string; fileName: string } 
   }
 
   const domain = parts[0];
-  const fileName = path.basename(inputPath, path.extname(inputPath));
+  let fileName = path.basename(inputPath, path.extname(inputPath));
+
+  if (fileName.startsWith('use-')) {
+    fileName = fileName.substring(4);
+  }
 
   return {
     domain,
@@ -130,8 +186,11 @@ async function main() {
 
     // 파일 작성
     fs.writeFileSync(handlerFilePath, handlerContent);
-
     console.log(`MSW 핸들러 생성 완료: src/domains/${domain}/mocks/${fileName}.ts`);
+
+    // handlers.ts에 새 핸들러 추가
+    console.log('\nhandlers.ts에 새 핸들러를 추가합니다.');
+    addToHandlersFile(domain, fileName);
   } catch (error) {
     console.error('오류 발생:', error instanceof Error ? error.message : error);
     process.exit(1);

--- a/src/domains/profile/__tests__/basic-info-email.test.tsx
+++ b/src/domains/profile/__tests__/basic-info-email.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { render, loginAsUser } from '@/__tests__/utils/test-utils';
@@ -53,7 +53,9 @@ describe('basic-info-email 컴포넌트 단위 테스트', () => {
     await user.type(emailInput, 'new123@daum.net');
     await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(screen.getByText('교직 이메일이 아닙니다.')).toBeInTheDocument();
+    expect(
+      screen.getByText('유효하지 않은 교사 이메일입니다. 교육청 이메일 도메인만 허용됩니다.'),
+    ).toBeInTheDocument();
     expect(emailInput).toHaveClass('border-red-500');
   });
 
@@ -66,7 +68,10 @@ describe('basic-info-email 컴포넌트 단위 테스트', () => {
     await user.type(emailInput, 'test@edukit.co.kr');
     await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(global.alert).toHaveBeenCalledWith('이미 등록된 회원입니다.');
+    await waitFor(() => {
+      expect(screen.getByText('이미 등록된 이메일입니다.')).toBeInTheDocument();
+    });
+    expect(emailInput).toHaveClass('border-red-500');
   });
 
   it('이메일 변경 성공 시 성공 메시지가 표시되고 뷰 모드로 전환된다', async () => {

--- a/src/domains/profile/__tests__/basic-info-password.test.tsx
+++ b/src/domains/profile/__tests__/basic-info-password.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { render, loginAsUser } from '@/__tests__/utils/test-utils';
@@ -34,11 +34,15 @@ describe('basic-info-password 컴포넌트 단위 테스트', () => {
     const currentPasswordInput = screen.getByPlaceholderText('현재 비밀번호');
     const newPasswordInput = screen.getByPlaceholderText('새 비밀번호');
     const confirmPasswordInput = screen.getByPlaceholderText('새 비밀번호 확인');
+
     await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(screen.getByTestId('current-password-error')).toBeInTheDocument();
-    expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
-    expect(screen.getByTestId('confirm-password-error')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('current-password-error')).toBeInTheDocument();
+      expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
+      expect(screen.getByTestId('confirm-password-error')).toBeInTheDocument();
+    });
+
     expect(currentPasswordInput).toHaveClass('border-red-500');
     expect(newPasswordInput).toHaveClass('border-red-500');
     expect(confirmPasswordInput).toHaveClass('border-red-500');
@@ -52,9 +56,11 @@ describe('basic-info-password 컴포넌트 단위 테스트', () => {
     await user.type(currentPasswordInput, 'password123!');
     await user.type(newPasswordInput, '123');
     await user.type(confirmPasswordInput, '123');
-    await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
+    });
+
     expect(newPasswordInput).toHaveClass('border-red-500');
   });
 
@@ -65,10 +71,15 @@ describe('basic-info-password 컴포넌트 단위 테스트', () => {
 
     await user.type(currentPasswordInput, 'password123!');
     await user.type(newPasswordInput, 'newPassword123!');
-    await user.type(confirmPasswordInput, 'differentPassword');
-    await user.click(screen.getByRole('button', { name: '저장' }));
+    await user.type(confirmPasswordInput, 'different123!');
 
-    expect(screen.getByTestId('confirm-password-error')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-password-error')).toBeInTheDocument();
+      expect(
+        screen.getByText('새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.'),
+      ).toBeInTheDocument();
+    });
+
     expect(confirmPasswordInput).toHaveClass('border-red-500');
   });
 
@@ -82,9 +93,11 @@ describe('basic-info-password 컴포넌트 단위 테스트', () => {
     await user.type(confirmPasswordInput, 'newPassword123!');
     await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(global.alert).toHaveBeenCalledWith(
-      '현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('current-password-error')).toBeInTheDocument();
+    });
+
+    expect(currentPasswordInput).toHaveClass('border-red-500');
   });
 
   it('기존 비밀번호와 동일한 새 비밀번호 사용 시 에러 메시지가 표시된다', async () => {
@@ -95,11 +108,15 @@ describe('basic-info-password 컴포넌트 단위 테스트', () => {
     await user.type(currentPasswordInput, 'password123!');
     await user.type(newPasswordInput, 'password123!');
     await user.type(confirmPasswordInput, 'password123!');
-    await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(global.alert).toHaveBeenCalledWith(
-      '새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다.',
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('new-password-error')).toBeInTheDocument();
+      expect(
+        screen.getByText('새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(newPasswordInput).toHaveClass('border-red-500');
   });
 
   it('정상적인 비밀번호 변경이 성공한다', async () => {
@@ -112,7 +129,9 @@ describe('basic-info-password 컴포넌트 단위 테스트', () => {
     await user.type(confirmPasswordInput, 'newPassword123!');
     await user.click(screen.getByRole('button', { name: '저장' }));
 
-    expect(global.alert).toHaveBeenCalledWith('비밀번호가 성공적으로 변경되었습니다.');
+    await waitFor(() => {
+      expect(global.alert).toHaveBeenCalledWith('비밀번호가 성공적으로 변경되었습니다.');
+    });
   });
 
   it('비밀번호 수정을 취소할 수 있다', async () => {

--- a/src/domains/profile/__tests__/profile-edit.test.tsx
+++ b/src/domains/profile/__tests__/profile-edit.test.tsx
@@ -62,9 +62,7 @@ describe('profile-edit 컴포넌트 단위 테스트', () => {
       await user.click(checkButton);
 
       await waitFor(() => {
-        expect(global.alert).toHaveBeenCalledWith(
-          '금칙어가 들어갔습니다. 다른 닉네임을 사용해주세요.',
-        );
+        expect(global.alert).toHaveBeenCalledWith('입력하신 닉네임은 유효하지 않습니다.');
       });
     });
 
@@ -77,7 +75,7 @@ describe('profile-edit 컴포넌트 단위 테스트', () => {
       await user.click(checkButton);
 
       await waitFor(() => {
-        expect(global.alert).toHaveBeenCalledWith('현재 사용 중인 닉네임입니다.');
+        expect(global.alert).toHaveBeenCalledWith('입력하신 닉네임은 중복된 닉네임입니다.');
       });
     });
 

--- a/src/domains/profile/__tests__/profile.integration.test.tsx
+++ b/src/domains/profile/__tests__/profile.integration.test.tsx
@@ -109,4 +109,81 @@ describe('profile 기능 통합 테스트', () => {
 
     expect(screen.getByText('내 프로필')).toBeInTheDocument();
   });
+
+  it('회원 탈퇴하기 버튼을 클릭하면 확인 모달이 표시된다', async () => {
+    await loginAsUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    const withdrawButton = screen.getByRole('button', { name: '회원 탈퇴하기' });
+    await user.click(withdrawButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('탈퇴하기')).toBeInTheDocument();
+  });
+
+  it('회원 탈퇴 모달에서 취소하기 버튼을 누르면 모달이 닫힌다', async () => {
+    await loginAsUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    const withdrawButton = screen.getByRole('button', { name: '회원 탈퇴하기' });
+    await user.click(withdrawButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const cancelButton = screen.getByRole('button', { name: '취소' });
+    await user.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('내 프로필')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '회원 탈퇴하기' })).toBeInTheDocument();
+  });
+
+  it('회원 탈퇴 모달에서 탈퇴하기 버튼을 누르면 회원 탈퇴가 실행되고 성공 메시지가 표시된다', async () => {
+    await loginAsUser();
+
+    render(<Mypage />);
+
+    await waitFor(() => {
+      const loading = document.querySelector('[class*="animate-spin"]');
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    const withdrawButton = screen.getByRole('button', { name: '회원 탈퇴하기' });
+    await user.click(withdrawButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const confirmButton = screen.getByRole('button', { name: '탈퇴하기' });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(global.alert).toHaveBeenCalledWith('회원 탈퇴가 완료되었습니다.');
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/domains/profile/apis/mutations/use-delete-withdraw.ts
+++ b/src/domains/profile/apis/mutations/use-delete-withdraw.ts
@@ -7,7 +7,7 @@ export const deleteWithdraw = async () => {
   return api.delete<ApiResponseWithoutData>('/api/v1/users/withdraw');
 };
 
-export const useGetCheckValidNickname = () => {
+export const useDeleteWithdraw = () => {
   return useMutation<ApiResponseWithoutData, Error>({
     mutationFn: deleteWithdraw,
     onError: (error) => {

--- a/src/domains/profile/apis/mutations/use-delete-withdraw.ts
+++ b/src/domains/profile/apis/mutations/use-delete-withdraw.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { api } from '@/shared/lib/api';
+import { type ApiResponseWithoutData } from '@/shared/types/response';
+
+export const deleteWithdraw = async () => {
+  return api.delete<ApiResponseWithoutData>('/api/v1/users/withdraw');
+};
+
+export const useGetCheckValidNickname = () => {
+  return useMutation<ApiResponseWithoutData, Error>({
+    mutationFn: deleteWithdraw,
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+};

--- a/src/domains/profile/apis/mutations/use-get-check-valid-nickname.ts
+++ b/src/domains/profile/apis/mutations/use-get-check-valid-nickname.ts
@@ -12,8 +12,5 @@ export const getCheckValidNickname = async (nickname: string) => {
 export const useGetCheckValidNickname = () => {
   return useMutation<GetCheckValidNicknameResponse, Error, string>({
     mutationFn: getCheckValidNickname,
-    onError: (error) => {
-      alert(error.message);
-    },
   });
 };

--- a/src/domains/profile/apis/mutations/use-patch-after-login-password.ts
+++ b/src/domains/profile/apis/mutations/use-patch-after-login-password.ts
@@ -17,8 +17,5 @@ export const patchAfterLoginPassword = async ({
 export const usePatchAfterLoginPassword = () => {
   return useMutation<ApiResponseWithoutData, Error, EditPasswordBody>({
     mutationFn: patchAfterLoginPassword,
-    onError: (error) => {
-      alert(error.message);
-    },
   });
 };

--- a/src/domains/profile/apis/mutations/use-patch-email.ts
+++ b/src/domains/profile/apis/mutations/use-patch-email.ts
@@ -17,8 +17,5 @@ export const usePatchEmail = () => {
         queryKey: ['profile'],
       });
     },
-    onError: (error) => {
-      alert(error.message);
-    },
   });
 };

--- a/src/domains/profile/components/basic-info-email-edit.tsx
+++ b/src/domains/profile/components/basic-info-email-edit.tsx
@@ -24,6 +24,7 @@ export default function BasicInfoEmailEdit({ currentEmail, onView }: EmailEditPr
     register,
     formState: { errors },
     handleSubmit,
+    setError,
   } = useForm<EmailEditType>({
     resolver: zodResolver(emailEditSchema),
     defaultValues: {
@@ -37,6 +38,12 @@ export default function BasicInfoEmailEdit({ currentEmail, onView }: EmailEditPr
       onSuccess: () => {
         alert('이메일이 성공적으로 변경되었습니다.');
         onView();
+      },
+      onError: (error) => {
+        setError('email', {
+          type: 'server',
+          message: error.message || '이메일 변경 중 오류가 발생했습니다.',
+        });
       },
     });
   };

--- a/src/domains/profile/components/basic-info-password-edit.tsx
+++ b/src/domains/profile/components/basic-info-password-edit.tsx
@@ -8,12 +8,16 @@ import { Input } from '@/shared/components/ui/input/input';
 
 const passwordEditSchema = z
   .object({
-    currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요.'),
+    currentPassword: passwordSchema,
     newPassword: passwordSchema,
-    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+    confirmPassword: passwordSchema,
+  })
+  .refine((data) => data.currentPassword !== data.newPassword, {
+    message: '새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다.',
+    path: ['newPassword'],
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
-    message: '새 비밀번호가 일치하지 않습니다.',
+    message: '새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.',
     path: ['confirmPassword'],
   });
 
@@ -31,6 +35,7 @@ export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
     formState: { errors },
     handleSubmit,
     reset,
+    setError,
   } = useForm<PasswordEditType>({
     resolver: zodResolver(passwordEditSchema),
     defaultValues: {
@@ -53,6 +58,12 @@ export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
           reset();
           onView();
         },
+        onError: (error) => {
+          setError('currentPassword', {
+            type: 'server',
+            message: error.message || '현재 비밀번호가 일치하지 않습니다.',
+          });
+        },
       },
     );
   };
@@ -61,8 +72,8 @@ export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
       <div className="flex w-full items-center gap-7">
         <span className="text-slate-500">비밀번호</span>
-        <div className="flex flex-1 flex-col gap-1">
-          <div className="space-y-3">
+        <div className="flex flex-1 flex-col gap-3">
+          <div className="relative">
             <Input
               className={`h-10 text-lg ${
                 errors.currentPassword
@@ -73,6 +84,14 @@ export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
               placeholder="현재 비밀번호"
               {...register('currentPassword')}
             />
+            {errors.currentPassword ? (
+              <p data-testid="current-password-error" className="mt-1 text-xs text-red-500">
+                {errors.currentPassword.message}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="relative">
             <Input
               className={`h-10 text-lg ${
                 errors.newPassword
@@ -83,6 +102,14 @@ export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
               placeholder="새 비밀번호"
               {...register('newPassword')}
             />
+            {errors.newPassword ? (
+              <p data-testid="new-password-error" className="mt-1 text-xs text-red-500">
+                {errors.newPassword.message}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="relative">
             <Input
               className={`h-10 text-lg ${
                 errors.confirmPassword
@@ -93,27 +120,14 @@ export default function BasicInfoPasswordEdit({ onView }: PasswordEditProps) {
               placeholder="새 비밀번호 확인"
               {...register('confirmPassword')}
             />
+            {errors.confirmPassword ? (
+              <p data-testid="confirm-password-error" className="mt-1 text-xs text-red-500">
+                {errors.confirmPassword.message}
+              </p>
+            ) : null}
           </div>
-          {errors.currentPassword || errors.newPassword || errors.confirmPassword ? (
-            <div className="space-y-1">
-              {errors.currentPassword ? (
-                <p data-testid="current-password-error" className="text-xs text-red-500">
-                  {errors.currentPassword.message}
-                </p>
-              ) : null}
-              {errors.newPassword ? (
-                <p data-testid="new-password-error" className="text-xs text-red-500">
-                  {errors.newPassword.message}
-                </p>
-              ) : null}
-              {errors.confirmPassword ? (
-                <p data-testid="confirm-password-error" className="text-xs text-red-500">
-                  {errors.confirmPassword.message}
-                </p>
-              ) : null}
-            </div>
-          ) : null}
         </div>
+
         <div className="flex gap-2">
           <button
             type="button"

--- a/src/domains/profile/components/confirm-withdraw-modal.tsx
+++ b/src/domains/profile/components/confirm-withdraw-modal.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { TriangleAlert } from 'lucide-react';
+
+import Modal from '@/shared/components/ui/modal/modal';
+
+interface ConfirmWithdrawModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export default function ConfirmWithdrawModal({
+  open,
+  onOpenChange,
+  onConfirm,
+}: ConfirmWithdrawModalProps) {
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <Modal.Overlay />
+      <Modal.Content aria-describedby={undefined} className="max-w-xl rounded-xl px-8 py-6">
+        <Modal.Close />
+        <Modal.Title className="flex flex-col items-center justify-center gap-4 text-[20px]">
+          <div className="flex h-16 w-16 items-center justify-center">
+            <TriangleAlert className="h-8 w-8 text-red-600" />
+          </div>
+          <span className="text-gray-800">정말 탈퇴하시겠어요?</span>
+        </Modal.Title>
+        <Modal.Description className="font-bold !text-black">
+          탈퇴 시 모든 계정 정보와 데이터가 삭제되며, 복구가 불가능합니다.
+        </Modal.Description>
+
+        <div className="mt-6 flex justify-center gap-4">
+          <button
+            onClick={handleCancel}
+            className="rounded-md bg-slate-800 px-6 py-2 font-bold text-white transition-colors hover:bg-slate-950"
+          >
+            취소
+          </button>
+          <button
+            data-testid="modal-remove-button"
+            onClick={onConfirm}
+            className="rounded-md bg-red-700 px-6 py-2 font-bold text-white hover:bg-red-600"
+          >
+            탈퇴하기
+          </button>
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/src/domains/profile/components/profile-edit.tsx
+++ b/src/domains/profile/components/profile-edit.tsx
@@ -31,17 +31,13 @@ export default function ProfileEdit({ profile, onChangeView }: ProfileEditProps)
 
   const handleNicknameCheck = () => {
     getCheckValidNickname(nickname, {
-      onSuccess: (data) => {
-        if (!data.isDuplicated && !data.isInvalid) {
-          setIsNicknameValidated(true);
-          alert('사용 가능한 닉네임입니다!');
-        } else if (data.isDuplicated) {
-          setIsNicknameValidated(false);
-          alert('현재 사용 중인 닉네임입니다.');
-        } else if (data.isInvalid) {
-          setIsNicknameValidated(false);
-          alert('금칙어가 들어갔습니다. 다른 닉네임을 사용해주세요.');
-        }
+      onSuccess: () => {
+        setIsNicknameValidated(true);
+        alert('사용 가능한 닉네임입니다!');
+      },
+      onError: (error) => {
+        setIsNicknameValidated(false);
+        alert(error.message);
       },
     });
   };

--- a/src/domains/profile/components/profile-view.tsx
+++ b/src/domains/profile/components/profile-view.tsx
@@ -5,6 +5,8 @@ import { CheckCircle2 } from 'lucide-react';
 import Image from 'next/image';
 
 import { usePostSendEmail } from '@/domains/auth/apis/mutations/use-post-send-email';
+import { useDeleteWithdraw } from '@/domains/profile/apis/mutations/use-delete-withdraw';
+import ConfirmWithdrawModal from '@/domains/profile/components/confirm-withdraw-modal';
 import EmailSentModal from '@/domains/profile/components/email-sent-modal';
 import type { ProfileResponse } from '@/domains/profile/types/profile';
 
@@ -16,17 +18,37 @@ interface ProfileViewProps {
 }
 
 export default function ProfileView({ profile, onChangeEdit }: ProfileViewProps) {
-  const [open, setOpen] = useState(false);
+  const [emailModalOpen, setEmailModalOpen] = useState(false);
+  const [confirmWithdrawModalOpen, setConfirmWithdrawModalOpen] = useState(false);
 
   const { mutate: postSendEmail } = usePostSendEmail();
+  const { mutate: deleteWithdraw, isPending: isWithdrawPending } = useDeleteWithdraw();
 
   const handleSendEmail = () => {
     postSendEmail(undefined, {
       onSuccess: () => {
-        setOpen(true);
+        setEmailModalOpen(true);
       },
       onError: (error) => {
         alert(error.message);
+      },
+    });
+  };
+
+  const handleWithdrawClick = () => {
+    setConfirmWithdrawModalOpen(true);
+  };
+
+  const handleConfirmWithdraw = () => {
+    deleteWithdraw(undefined, {
+      onSuccess: () => {
+        alert('회원 탈퇴가 완료되었습니다.');
+      },
+      onError: (error) => {
+        alert(error.message);
+      },
+      onSettled: () => {
+        setConfirmWithdrawModalOpen(false);
       },
     });
   };
@@ -72,13 +94,28 @@ export default function ProfileView({ profile, onChangeEdit }: ProfileViewProps)
           <span className="pt-[2px] text-sm">고등학교</span>
         </div>
       </div>
-      <button
-        onClick={onChangeEdit}
-        className="w-40 rounded-md bg-blue-800 px-6 py-2 text-white hover:bg-blue-950"
-      >
-        프로필 수정하기
-      </button>
-      <EmailSentModal open={open} onOpenChange={setOpen} />
+      <div className="flex gap-2">
+        <button
+          onClick={onChangeEdit}
+          className="w-40 rounded-md bg-blue-800 px-6 py-2 text-white hover:bg-blue-950"
+        >
+          프로필 수정하기
+        </button>
+        <button
+          onClick={handleWithdrawClick}
+          className="rounded-md bg-red-600 px-6 py-2 text-white hover:bg-red-700"
+          disabled={isWithdrawPending}
+        >
+          회원 탈퇴하기
+        </button>
+      </div>
+
+      <EmailSentModal open={emailModalOpen} onOpenChange={setEmailModalOpen} />
+      <ConfirmWithdrawModal
+        open={confirmWithdrawModalOpen}
+        onOpenChange={setConfirmWithdrawModalOpen}
+        onConfirm={handleConfirmWithdraw}
+      />
     </div>
   );
 }

--- a/src/domains/profile/mocks/delete-withdraw.ts
+++ b/src/domains/profile/mocks/delete-withdraw.ts
@@ -1,0 +1,19 @@
+import { http, HttpResponse } from 'msw';
+
+export const deleteWithdraw = [
+  http.delete('/api/v1/users/withdraw', async () => {
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '성공 메세지 작성',
+      },
+      {
+        status: 200,
+        headers: {
+          'Content-type': 'application/json',
+          'Set-Cookie': 'refreshToken=; HttpOnly; Path=/; SameSite=Lax',
+        },
+      },
+    );
+  }),
+];

--- a/src/domains/profile/mocks/get-check-valid-nickname.ts
+++ b/src/domains/profile/mocks/get-check-valid-nickname.ts
@@ -6,37 +6,31 @@ export const getCheckValidNickname = [
     const nickname = url.searchParams.get('nickname');
 
     if (nickname === 'ㅇㅇ') {
-      return HttpResponse.json({
-        status: 200,
-        code: 'EDMT-200',
-        message: '요청에 성공했습니다.',
-        data: {
-          isInvalid: true,
-          isDuplicated: false,
+      return HttpResponse.json(
+        {
+          code: 'M-40004',
+          message: '입력하신 닉네임은 유효하지 않습니다.',
         },
-      });
+        { status: 200 },
+      );
     }
 
     if (nickname === '선생님1') {
-      return HttpResponse.json({
-        status: 200,
-        code: 'EDMT-200',
-        message: '요청에 성공했습니다.',
-        data: {
-          isInvalid: false,
-          isDuplicated: true,
+      return HttpResponse.json(
+        {
+          code: 'M-40005',
+          message: '입력하신 닉네임은 중복된 닉네임입니다.',
         },
-      });
+        { status: 200 },
+      );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-200',
-      message: '요청에 성공했습니다.',
-      data: {
-        isInvalid: false,
-        isDuplicated: false,
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청에 성공했습니다.',
       },
-    });
+      { status: 200 },
+    );
   }),
 ];

--- a/src/domains/profile/mocks/get-profile.ts
+++ b/src/domains/profile/mocks/get-profile.ts
@@ -15,30 +15,27 @@ export const getProfile = [
     if (!validation.isValid) {
       return HttpResponse.json(
         {
-          status: 401,
-          code: 'EDMT-4010101',
+          code: 'A-40102',
           message: '유효하지 않은 토큰입니다.',
         },
-        { status: 401 },
+        { status: 200 },
       );
     }
 
     if (validation.isExpired) {
       return HttpResponse.json(
         {
-          status: 401,
-          code: 'EDMT-4010102',
-          message: '만료된 토큰입니다.',
+          code: 'A-40102',
+          message: '유효하지 않은 토큰입니다.',
         },
-        { status: 401 },
+        { status: 200 },
       );
     }
 
     if (validation.isNotVerified) {
       return HttpResponse.json(
         {
-          status: 200,
-          code: 'EDMT-200',
+          code: 'SUCCESS',
           message: '요청에 성공했습니다.',
           data: NOT_VERIFUED_USER_INFO_DATA,
         },
@@ -48,8 +45,7 @@ export const getProfile = [
 
     return HttpResponse.json(
       {
-        status: 200,
-        code: 'EDMT-200',
+        code: 'SUCCESS',
         message: '요청에 성공했습니다.',
         data: USER_INFO_DATA,
       },

--- a/src/domains/profile/mocks/patch-after-login-password.ts
+++ b/src/domains/profile/mocks/patch-after-login-password.ts
@@ -9,29 +9,31 @@ export const patchAfterLoginPassword = [
     if (currentPassword === 'password1234') {
       return HttpResponse.json(
         {
-          status: 400,
-          code: 'EDMT-4000402',
+          code: 'M-40006',
           message: '현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
         },
-        { status: 400 },
+        { status: 200 },
       );
     }
 
     if (currentPassword === 'password123!' && newPassword === 'password123!') {
       return HttpResponse.json(
         {
-          status: 400,
-          code: 'EDMT-4000403',
+          code: 'M-40007',
           message: '새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다.',
         },
-        { status: 400 },
+        { status: 200 },
       );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-200',
-      message: '비밀번호가 성공적으로 변경되었습니다.',
-    });
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청이 성공했습니다.',
+      },
+      {
+        status: 200,
+      },
+    );
   }),
 ];

--- a/src/domains/profile/mocks/patch-email.ts
+++ b/src/domains/profile/mocks/patch-email.ts
@@ -7,18 +7,19 @@ export const patchEmail = [
     if (email === 'test@edukit.co.kr') {
       return HttpResponse.json(
         {
-          status: 409,
-          code: 'EDMT-4090101',
-          message: '이미 등록된 회원입니다.',
+          code: 'M-40908',
+          message: '이미 등록된 이메일입니다.',
         },
-        { status: 409 },
+        { status: 200 },
       );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-200',
-      message: '이메일이 성공적으로 변경되었습니다.',
-    });
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청이 성공했습니다.',
+      },
+      { status: 200 },
+    );
   }),
 ];

--- a/src/domains/profile/mocks/patch-profile.ts
+++ b/src/domains/profile/mocks/patch-profile.ts
@@ -2,10 +2,12 @@ import { http, HttpResponse } from 'msw';
 
 export const patchProfile = [
   http.patch('/api/v1/users/profile', async () => {
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-200',
-      message: '요청에 성공했습니다.',
-    });
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청에 성공했습니다.',
+      },
+      { status: 200 },
+    );
   }),
 ];

--- a/src/shared/mocks/handlers.ts
+++ b/src/shared/mocks/handlers.ts
@@ -12,6 +12,7 @@ import { getNoticeDetail } from '../../domains/notice/mocks/get-notice-detail';
 import { getNoticeList } from '../../domains/notice/mocks/get-notice-list';
 import { patchAdminNotice } from '../../domains/notice/mocks/patch-admin-notice';
 import { postAdminNotice } from '../../domains/notice/mocks/post-admin-notice';
+import { deleteWithdraw } from '../../domains/profile/mocks/delete-withdraw';
 import { getCheckValidNickname } from '../../domains/profile/mocks/get-check-valid-nickname';
 import { getProfile } from '../../domains/profile/mocks/get-profile';
 import { patchAfterLoginPassword } from '../../domains/profile/mocks/patch-after-login-password';
@@ -56,4 +57,5 @@ export const handlers = [
   ...postAdminNotice,
   ...patchAdminNotice,
   ...deleteAdminNotice,
+  ...deleteWithdraw,
 ];

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -235,7 +235,9 @@ test.describe('프로필 관리 E2E 테스트', () => {
     await page.fill('input[placeholder="새 비밀번호"]', 'newPassword123!');
     await page.fill('input[placeholder="새 비밀번호 확인"]', 'differentPassword');
     await page.click('button:has-text("저장")');
-    await expect(page.locator('text=새 비밀번호가 일치하지 않습니다.')).toBeVisible();
+    await expect(
+      page.locator('text=새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.'),
+    ).toBeVisible();
 
     // 기존 비밀번호와 같은 값 입력
     await page.fill('input[placeholder="새 비밀번호"]', currentPassword);


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-392]

## 🌱 주요 변경 사항

1. profile 도메인에서 사용되는 api 명세 수정에 따른 mock api 코드 리팩토링
2. 이메일 수정 에러 ui 수정
3. 회원 탈퇴 api 연동 및 탈퇴 mock api 구현
4. profile 닉네임 변경 확인 로직 api 명세 수정에 따른 로직 수정
5. mock 코드 자동 생성해주는 스크립트 코드에 mock 핸들러에 추가하는 로직 구현
6. PASSWORD 변경할때 발생하는 에러 ui 수정
7. 정말 회원 탈퇴를 할건지 물어보는 modal 컴포넌트 구현
8. api 명세 변경, 에러 ui 변경에 따른 테스트 코드 수정
9. 회원 탈퇴 테스트 케이스 추가

## 📸 스크린샷 (선택)

<img width="1145" height="667" alt="스크린샷 2025-08-26 오후 3 47 10" src="https://github.com/user-attachments/assets/f004c4ea-28b9-407f-bbe5-5c838a28132f" />



[EDMT-392]: https://bbangbbangz.atlassian.net/browse/EDMT-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 마이페이지에 회원 탈퇴 흐름 추가: 확인 모달, 진행 중 버튼 비활성화, 완료 알림.
- 개선 사항
  - 비밀번호 변경: 필드별 인라인 오류 메시지 도입, 확인 불일치 문구 업데이트, 기존 비밀번호와 동일 불가 검증 추가.
  - 이메일 변경: 서버 오류를 인라인 메시지로 표시(알림창 대체).
  - 닉네임 검사: 성공 시 일반 성공 알림, 중복/유효성 문제는 오류 메시지로 안내. 관련 문구 업데이트.
  - 이메일 인증 안내 모달 표시 로직 개선.
- 테스트/모킹
  - 탈퇴 및 프로필 관련 MSW 핸들러와 통합 테스트 추가/정비.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->