### PR TITLE
[EDMT-418] 공지사항 어드민 기능 테스트 케이스 수정

### DIFF
--- a/src/domains/notice/__tests__/notice-admin.integration.test.tsx
+++ b/src/domains/notice/__tests__/notice-admin.integration.test.tsx
@@ -348,38 +348,4 @@ describe('공지사항 어드민 통합 테스트', () => {
       });
     });
   });
-
-  describe('로딩 상태 및 사용자 경험', () => {
-    beforeEach(async () => {
-      await loginAsAdmin();
-    });
-
-    it('로딩 중일 때 버튼이 비활성화되고 텍스트가 변경된다', () => {
-      render(<WriteNotice />);
-
-      const submitButton = screen.getByRole('button', { name: '작성하기' });
-      expect(submitButton).toBeInTheDocument();
-      expect(submitButton).not.toBeDisabled();
-    });
-  });
-
-  describe('에러 처리', () => {
-    beforeEach(async () => {
-      await loginAsAdmin();
-    });
-
-    it('네트워크 오류 시 컴포넌트가 정상적으로 렌더링된다', () => {
-      render(<WriteNotice />);
-
-      expect(screen.getByRole('button', { name: '작성하기' })).toBeInTheDocument();
-    });
-
-    it('권한 없는 사용자가 접근했을 때 적절히 처리된다', async () => {
-      clearAllTestMocks();
-      await loginAsUser();
-
-      const { container } = render(<WriteNoticeButton />);
-      expect(container.firstChild).toBeNull();
-    });
-  });
 });

--- a/src/domains/notice/__tests__/notice-admin.integration.test.tsx
+++ b/src/domains/notice/__tests__/notice-admin.integration.test.tsx
@@ -8,11 +8,17 @@ import EditDeleteNoticeButton from '@/domains/notice/components/edit-delete-noti
 import EditNotice from '@/domains/notice/components/edit-notice';
 import WriteNotice from '@/domains/notice/components/write-notice';
 import WriteNoticeButton from '@/domains/notice/components/write-notice-button';
-import type { DetailNoticeResponse } from '@/domains/notice/types/notice';
+import type { DetailNoticeResponse, UploadedImageInfo } from '@/domains/notice/types/notice';
 
 jest.mock('next/cache', () => ({
   revalidatePath: jest.fn(),
 }));
+
+jest.mock('@/shared/lib/actions/revalidateNotice', () => ({
+  revalidateNotice: jest.fn(),
+}));
+
+global.alert = jest.fn();
 
 const mockGetHTML = jest.fn().mockReturnValue('');
 
@@ -25,6 +31,16 @@ jest.mock('@/shared/components/ui/editor/tiptap-editor', () => {
     return React.createElement('div', {
       'data-testid': 'tiptap-editor',
       className: props.className,
+      onClick: () => {
+        if (props.onImageUpload) {
+          const mockImageInfo: UploadedImageInfo = {
+            tmpFileUrl: 'https://tmp.example.com/test.jpg',
+            fileUrl: 'https://cdn.example.com/test.jpg',
+            fileKey: 'test-file-key-1',
+          };
+          props.onImageUpload(mockImageInfo);
+        }
+      },
     });
   }
 
@@ -33,6 +49,23 @@ jest.mock('@/shared/components/ui/editor/tiptap-editor', () => {
     default: React.forwardRef(MockTipTapEditor),
   };
 });
+
+const mockHandleImageUpload = jest.fn();
+const mockExtractUsedFileKeys = jest.fn().mockReturnValue(['test-key-1', 'test-key-2']);
+const mockConvertTmpUrlsToFileUrls = jest.fn((content) => content);
+const mockResetFileKeys = jest.fn();
+
+jest.mock('@/domains/notice/hooks/use-notice-file-keys', () => ({
+  useNoticeFileKeys: jest.fn(() => ({
+    handleImageUpload: mockHandleImageUpload,
+    extractUsedFileKeys: mockExtractUsedFileKeys,
+    convertTmpUrlsToFileUrls: mockConvertTmpUrlsToFileUrls,
+    resetFileKeys: mockResetFileKeys,
+    uploadedImagesCount: 0,
+    existingImagesCount: 0,
+    totalImagesCount: 0,
+  })),
+}));
 
 const mockNoticeDetail: DetailNoticeResponse = {
   noticeId: 1,
@@ -43,7 +76,7 @@ const mockNoticeDetail: DetailNoticeResponse = {
   noticeFileKeys: ['1', '2', '3'],
 };
 
-describe('notice-admin 기능 통합 테스트', () => {
+describe('공지사항 어드민 통합 테스트', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(async () => {
@@ -51,15 +84,19 @@ describe('notice-admin 기능 통합 테스트', () => {
     clearAllTestMocks();
 
     mockGetHTML.mockReturnValue('');
+    mockHandleImageUpload.mockClear();
+    mockExtractUsedFileKeys.mockClear();
+    mockConvertTmpUrlsToFileUrls.mockClear();
+    (global.alert as jest.Mock).mockClear();
   });
 
   describe('어드민 권한별 글쓰기 버튼 노출', () => {
-    it('비로그인 상태에서는 글쓰기 버튼이 없다', () => {
+    it('비로그인 상태에서는 글쓰기 버튼이 보이지 않는다', () => {
       const { container } = render(<WriteNoticeButton />);
       expect(container.firstChild).toBeNull();
     });
 
-    it('일반 사용자 로그인 시 글쓰기 버튼이 없다', async () => {
+    it('일반 사용자 로그인 시 글쓰기 버튼이 보이지 않는다', async () => {
       await loginAsUser();
       const { container } = render(<WriteNoticeButton />);
       expect(container.firstChild).toBeNull();
@@ -68,6 +105,7 @@ describe('notice-admin 기능 통합 테스트', () => {
     it('어드민 로그인 시 글쓰기 버튼이 보인다', async () => {
       await loginAsAdmin();
       render(<WriteNoticeButton />);
+
       expect(screen.getByText('글쓰기')).toBeInTheDocument();
       expect(screen.getByRole('link', { name: '글쓰기' })).toHaveAttribute(
         'href',
@@ -81,8 +119,9 @@ describe('notice-admin 기능 통합 테스트', () => {
       await loginAsAdmin();
     });
 
-    it('작성 폼 렌더링 확인', () => {
+    it('작성 폼이 정상적으로 렌더링된다', () => {
       render(<WriteNotice />);
+
       expect(screen.getByText('공지')).toBeInTheDocument();
       expect(screen.getByText('이벤트')).toBeInTheDocument();
       expect(screen.getByPlaceholderText('제목')).toBeInTheDocument();
@@ -92,10 +131,12 @@ describe('notice-admin 기능 통합 테스트', () => {
 
     it('카테고리 선택이 정상적으로 동작한다', async () => {
       render(<WriteNotice />);
+
       const noticeButton = screen.getByText('공지');
       const eventButton = screen.getByText('이벤트');
 
       expect(noticeButton).toHaveClass('bg-slate-800');
+      expect(eventButton).toHaveClass('bg-white');
 
       await user.click(eventButton);
 
@@ -106,43 +147,72 @@ describe('notice-admin 기능 통합 테스트', () => {
     it.each([
       ['제목만 입력', '테스트 제목', ''],
       ['내용만 입력', '', '<p>테스트 내용입니다.</p>'],
-    ])(
-      '"%s" 상태에서 작성하기 클릭 시 제목과 내용을 모두 입력해달라는 alert 메세지가 표시된다',
-      async (_, title, content) => {
-        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
-        try {
-          render(<WriteNotice />);
-
-          if (title) {
-            const titleInput = screen.getByPlaceholderText('제목');
-            await user.type(titleInput, title);
-          }
-          if (content) {
-            mockGetHTML.mockReturnValue(content);
-          }
-
-          const submitButton = screen.getByRole('button', { name: '작성하기' });
-          await user.click(submitButton);
-
-          expect(alertSpy).toHaveBeenCalledWith('제목과 내용을 모두 입력해주세요.');
-        } finally {
-          alertSpy.mockRestore();
-        }
-      },
-    );
-
-    it('이벤트 태그를 클릭하고, 제목 및 내용을 입력하고 작성하기 버튼을 클릭 시 공지사항 작성 api 요청이 성공하고 notice 페이지로 이동한다', async () => {
+      ['공백으로만 구성된 제목과 내용', '   ', '<p>   </p>'],
+    ])('%s 상태에서 작성하기 클릭 시 유효성 검사 알림이 표시된다', async (_, title, content) => {
       render(<WriteNotice />);
+
+      if (title) {
+        const titleInput = screen.getByPlaceholderText('제목');
+        await user.type(titleInput, title);
+      }
+
+      if (content) {
+        mockGetHTML.mockReturnValue(content);
+      }
+
+      const submitButton = screen.getByRole('button', { name: '작성하기' });
+      await user.click(submitButton);
+
+      expect(global.alert).toHaveBeenCalledWith('제목과 내용을 모두 입력해주세요.');
+    });
+
+    it('정상적인 공지사항을 작성하고 제출하면 공지사항 목록으로 이동한다', async () => {
+      render(<WriteNotice />);
+
       await user.click(screen.getByText('이벤트'));
 
       const titleInput = screen.getByPlaceholderText('제목');
-      await user.type(titleInput, '테스트 공지사항 제목');
+      await user.type(titleInput, '새로운 이벤트 공지사항');
 
-      mockGetHTML.mockReturnValue('<p>테스트 내용입니다.</p>');
+      mockGetHTML.mockReturnValue('<p>새로운 이벤트에 대한 상세 내용입니다.</p>');
 
-      await user.click(screen.getByRole('button', { name: '작성하기' }));
+      mockConvertTmpUrlsToFileUrls.mockReturnValue('<p>새로운 이벤트에 대한 상세 내용입니다.</p>');
 
-      expect(mockPush).toHaveBeenCalledWith('/notice');
+      const submitButton = screen.getByRole('button', { name: '작성하기' });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/notice');
+      });
+    });
+
+    it('이미지 업로드 시 handleImageUpload가 호출된다', async () => {
+      render(<WriteNotice />);
+
+      const editor = screen.getByTestId('tiptap-editor');
+      await user.click(editor);
+
+      expect(mockHandleImageUpload).toHaveBeenCalledWith({
+        tmpFileUrl: 'https://tmp.example.com/test.jpg',
+        fileUrl: 'https://cdn.example.com/test.jpg',
+        fileKey: 'test-file-key-1',
+      });
+    });
+
+    it('제출 시 파일 키 추출 및 URL 변환 함수가 호출된다', async () => {
+      render(<WriteNotice />);
+
+      const titleInput = screen.getByPlaceholderText('제목');
+      await user.type(titleInput, '테스트 제목');
+
+      const testContent = '<p>이미지가 포함된 내용</p>';
+      mockGetHTML.mockReturnValue(testContent);
+
+      const submitButton = screen.getByRole('button', { name: '작성하기' });
+      await user.click(submitButton);
+
+      expect(mockExtractUsedFileKeys).toHaveBeenCalledWith(testContent);
+      expect(mockConvertTmpUrlsToFileUrls).toHaveBeenCalledWith(testContent);
     });
   });
 
@@ -159,8 +229,9 @@ describe('notice-admin 기능 통합 테스트', () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it('어드민 시 수정/삭제 버튼 노출', () => {
+    it('어드민일 때 수정/삭제 버튼이 표시된다', () => {
       render(<EditDeleteNoticeButton noticeId={1} />);
+
       expect(screen.getByText('수정하기')).toBeInTheDocument();
       expect(screen.getByText('삭제하기')).toBeInTheDocument();
       expect(screen.getByRole('link', { name: '수정하기' })).toHaveAttribute(
@@ -169,38 +240,146 @@ describe('notice-admin 기능 통합 테스트', () => {
       );
     });
 
-    it('삭제 버튼 클릭 -> 모달 열림 -> 삭제 버튼 클릭 -> 삭제 api 요청이 성공하고 notice 페이지로 이동한다', async () => {
+    it('삭제 버튼 클릭 후 확인 모달에서 삭제를 진행하면 공지사항 목록으로 이동한다', async () => {
       render(<EditDeleteNoticeButton noticeId={1} />);
 
       await user.click(screen.getByText('삭제하기'));
 
-      await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
 
       await user.click(screen.getByRole('button', { name: '삭제' }));
 
-      expect(mockPush).toHaveBeenCalledWith('/notice');
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/notice');
+      });
+    });
+
+    it('수정 폼에서 기존 데이터가 정상적으로 로드된다', () => {
+      render(<EditNotice notice={mockNoticeDetail} />);
+
+      expect(screen.getByDisplayValue('테스트 공지사항')).toBeInTheDocument();
+      expect(screen.getByText('공지')).toHaveClass('bg-slate-800');
+      expect(screen.getByRole('button', { name: '수정하기' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
     });
 
     it('수정 폼에서 취소 버튼 클릭 시 이전 페이지로 이동한다', async () => {
       render(<EditNotice notice={mockNoticeDetail} />);
+
       await user.click(screen.getByRole('button', { name: '취소' }));
+
       expect(mockBack).toHaveBeenCalled();
     });
 
-    it('공지사항 수정을 수정하고 수정하기 버튼을 누르면 수정 api 요청이 성공하고 /notice/id 페이지로 이동한다.', async () => {
+    it('공지사항 정보를 수정하고 저장하면 해당 공지사항 상세 페이지로 이동한다', async () => {
       render(<EditNotice notice={mockNoticeDetail} />);
 
       const titleInput = screen.getByDisplayValue('테스트 공지사항');
       await user.clear(titleInput);
-      await user.type(titleInput, '수정된 테스트 공지사항');
+      await user.type(titleInput, '수정된 공지사항 제목');
 
       await user.click(screen.getByText('이벤트'));
 
-      mockGetHTML.mockReturnValue('<p>수정된 테스트 내용입니다.</p>');
+      mockGetHTML.mockReturnValue('<p>수정된 공지사항 내용입니다.</p>');
+      mockConvertTmpUrlsToFileUrls.mockReturnValue('<p>수정된 공지사항 내용입니다.</p>');
 
       await user.click(screen.getByRole('button', { name: '수정하기' }));
 
-      expect(mockPush).toHaveBeenCalledWith('/notice/1');
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/notice/1');
+      });
+    });
+
+    it('수정 시 유효성 검사가 정상적으로 동작한다', async () => {
+      render(<EditNotice notice={mockNoticeDetail} />);
+
+      const titleInput = screen.getByDisplayValue('테스트 공지사항');
+      await user.clear(titleInput);
+
+      mockGetHTML.mockReturnValue('');
+
+      await user.click(screen.getByRole('button', { name: '수정하기' }));
+
+      expect(global.alert).toHaveBeenCalledWith('제목과 내용을 모두 입력해주세요.');
+    });
+  });
+
+  describe('파일 관리 기능', () => {
+    beforeEach(async () => {
+      await loginAsAdmin();
+    });
+
+    it('수정 시 기존 파일 키와 새로운 파일을 올바르게 처리한다', async () => {
+      const noticeWithFiles: DetailNoticeResponse = {
+        ...mockNoticeDetail,
+        noticeFileKeys: ['existing-key-1', 'existing-key-2'],
+      };
+
+      render(<EditNotice notice={noticeWithFiles} />);
+
+      const titleInput = screen.getByDisplayValue('테스트 공지사항');
+      await user.type(titleInput, ' 수정됨');
+
+      mockGetHTML.mockReturnValue('<p>수정된 내용</p>');
+      mockExtractUsedFileKeys.mockReturnValue(['existing-key-1', 'new-key-1']);
+      mockConvertTmpUrlsToFileUrls.mockReturnValue('<p>수정된 내용</p>');
+
+      await user.click(screen.getByRole('button', { name: '수정하기' }));
+
+      expect(mockExtractUsedFileKeys).toHaveBeenCalledWith('<p>수정된 내용</p>');
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/notice/1');
+      });
+    });
+
+    it('이미지 업로드 후 파일 정보가 올바르게 처리된다', async () => {
+      render(<WriteNotice />);
+
+      const editor = screen.getByTestId('tiptap-editor');
+      await user.click(editor);
+
+      expect(mockHandleImageUpload).toHaveBeenCalledWith({
+        tmpFileUrl: 'https://tmp.example.com/test.jpg',
+        fileUrl: 'https://cdn.example.com/test.jpg',
+        fileKey: 'test-file-key-1',
+      });
+    });
+  });
+
+  describe('로딩 상태 및 사용자 경험', () => {
+    beforeEach(async () => {
+      await loginAsAdmin();
+    });
+
+    it('로딩 중일 때 버튼이 비활성화되고 텍스트가 변경된다', () => {
+      render(<WriteNotice />);
+
+      const submitButton = screen.getByRole('button', { name: '작성하기' });
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  describe('에러 처리', () => {
+    beforeEach(async () => {
+      await loginAsAdmin();
+    });
+
+    it('네트워크 오류 시 컴포넌트가 정상적으로 렌더링된다', () => {
+      render(<WriteNotice />);
+
+      expect(screen.getByRole('button', { name: '작성하기' })).toBeInTheDocument();
+    });
+
+    it('권한 없는 사용자가 접근했을 때 적절히 처리된다', async () => {
+      clearAllTestMocks();
+      await loginAsUser();
+
+      const { container } = render(<WriteNoticeButton />);
+      expect(container.firstChild).toBeNull();
     });
   });
 });

--- a/src/domains/notice/mocks/delete-admin-notice.ts
+++ b/src/domains/notice/mocks/delete-admin-notice.ts
@@ -13,29 +13,29 @@ export const deleteAdminNotice = [
     if (!validation.tokenData?.isAdmin) {
       return HttpResponse.json(
         {
-          status: 403,
-          code: 'EDMT-403',
-          message: '관리자 권한이 필요합니다.',
+          code: 'A-40304',
+          message: '접근 권한이 없는 사용자입니다. 교사 인증을 진행해주세요.',
         },
-        { status: 403 },
+        { status: 200 },
       );
     }
 
     if (noticeId === '999') {
       return HttpResponse.json(
         {
-          status: 404,
-          code: 'EDMT-4040301',
+          code: 'NO-40402',
           message: '해당 공지사항이 존재하지 않습니다.',
         },
-        { status: 404 },
+        { status: 200 },
       );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-20000',
-      message: '요청이 성공했습니다.',
-    });
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청이 성공했습니다.',
+      },
+      { status: 200 },
+    );
   }),
 ];

--- a/src/domains/notice/mocks/patch-admin-notice.ts
+++ b/src/domains/notice/mocks/patch-admin-notice.ts
@@ -14,11 +14,10 @@ export const patchAdminNotice = [
     if (!validation.tokenData?.isAdmin) {
       return HttpResponse.json(
         {
-          status: 403,
-          code: 'EDMT-403',
-          message: '관리자 권한이 필요합니다.',
+          code: 'A-40304',
+          message: '접근 권한이 없는 사용자입니다. 교사 인증을 진행해주세요.',
         },
-        { status: 403 },
+        { status: 200 },
       );
     }
 
@@ -27,40 +26,44 @@ export const patchAdminNotice = [
     if (!body.title?.trim() || !body.content?.replace(/<[^>]*>/g, '').trim()) {
       return HttpResponse.json(
         {
-          status: 400,
-          code: 'EDMT-400',
-          message: '제목과 내용을 모두 입력해주세요.',
+          code: 'FAIL-400',
+          message: 'validation 오류',
+          data: {
+            category: '카테고리는 필수입니다.',
+            title: '제목은 필수입니다.',
+            content: '내용은 필수입니다.',
+          },
         },
-        { status: 400 },
+        { status: 200 },
       );
     }
 
     if (noticeId === '999') {
       return HttpResponse.json(
         {
-          status: 404,
-          code: 'EDMT-4040301',
+          code: 'NO-40402',
           message: '해당 공지사항이 존재하지 않습니다.',
         },
-        { status: 404 },
+        { status: 200 },
       );
     }
 
     if (body.category !== 'announcement' && body.category !== 'event') {
       return HttpResponse.json(
         {
-          status: 400,
-          code: 'EDMT-4000302',
-          message: '공지사항 작성이 허용되지 않는 카테고리입니다.',
+          code: 'NO-40001',
+          message: '유효하지 않은 공지사항 카테고리입니다.',
         },
-        { status: 400 },
+        { status: 200 },
       );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-20000',
-      message: '요청이 성공했습니다.',
-    });
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청이 성공했습니다.',
+      },
+      { status: 200 },
+    );
   }),
 ];

--- a/src/domains/notice/mocks/post-admin-notice.ts
+++ b/src/domains/notice/mocks/post-admin-notice.ts
@@ -32,7 +32,7 @@ export const postAdminNotice = [
             content: '내용은 필수입니다.',
           },
         },
-        { status: 400 },
+        { status: 200 },
       );
     }
 

--- a/src/domains/notice/mocks/post-admin-notice.ts
+++ b/src/domains/notice/mocks/post-admin-notice.ts
@@ -12,11 +12,10 @@ export const postAdminNotice = [
     if (!validation.tokenData?.isAdmin) {
       return HttpResponse.json(
         {
-          status: 403,
-          code: 'EDMT-403',
-          message: '관리자 권한이 필요합니다.',
+          code: 'A-40304',
+          message: '접근 권한이 없는 사용자입니다. 교사 인증을 진행해주세요.',
         },
-        { status: 403 },
+        { status: 200 },
       );
     }
 
@@ -25,9 +24,13 @@ export const postAdminNotice = [
     if (!body.title?.trim() || !body.content?.replace(/<[^>]*>/g, '').trim()) {
       return HttpResponse.json(
         {
-          status: 400,
-          code: 'EDMT-400',
-          message: '제목과 내용을 모두 입력해주세요.',
+          code: 'FAIL-400',
+          message: 'validation 오류',
+          data: {
+            category: '카테고리는 필수입니다.',
+            title: '제목은 필수입니다.',
+            content: '내용은 필수입니다.',
+          },
         },
         { status: 400 },
       );
@@ -36,18 +39,19 @@ export const postAdminNotice = [
     if (body.category !== 'announcement' && body.category !== 'event') {
       return HttpResponse.json(
         {
-          status: 400,
-          code: 'EDMT-4000302',
-          message: '공지사항 작성이 허용되지 않는 카테고리입니다.',
+          code: 'NO-40001',
+          message: '유효하지 않은 공지사항 카테고리입니다.',
         },
-        { status: 400 },
+        { status: 200 },
       );
     }
 
-    return HttpResponse.json({
-      status: 200,
-      code: 'EDMT-20000',
-      message: '요청이 성공했습니다.',
-    });
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청이 성공했습니다.',
+      },
+      { status: 200 },
+    );
   }),
 ];


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-418]

## 🌱 주요 변경 사항

1. 어드민 api 명세 수정에 따른 mock api 수정
2. 어드민 공지사항 presigned-url, 공지사항 작성, 수정 테스트 케이스 추가



[EDMT-418]: https://bbangbbangz.atlassian.net/browse/EDMT-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 공지 관리자에서 이미지 업로드 흐름 강화: 임시 URL→최종 URL 변환 및 파일 키 관리 통합, 편집/저장 흐름 개선
- Bug Fixes
  - 권한·존재 여부·검증 오류 응답 메시지 및 코드 체계 정리, 검증 실패 시 필드별 안내 추가
  - 성공 응답 포맷 단순화 및 제출·삭제 후 내비게이션/알림 동작 안정화
- Tests
  - 통합 테스트 확대 및 한글화, 파일 관리·로딩·오류 시나리오 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->