### PR TITLE
[EDMT-424] 생활기록부 관리 페이지 퍼블리싱 및 무한스크롤 api 연동

### DIFF
--- a/src/app/(main)/(record)/manage-behavior/page.tsx
+++ b/src/app/(main)/(record)/manage-behavior/page.tsx
@@ -1,8 +1,8 @@
-import BehaviorRecordTable from '@/domains/record/components/record-manage/behavior-record-table';
+import ManageRecord from '@/domains/record/components/manage-record/manage-record';
 import { createPageMetadata } from '@/shared/constants/metadata';
 
 export const metadata = createPageMetadata('manageRecord', { url: '/manage-behavior' });
 
 export default function Page() {
-  return <BehaviorRecordTable />;
+  return <ManageRecord recordType="behavior" />;
 }

--- a/src/app/(main)/(record)/manage-career/page.tsx
+++ b/src/app/(main)/(record)/manage-career/page.tsx
@@ -1,8 +1,8 @@
-import CareerRecordTable from '@/domains/record/components/record-manage/career-record-table';
+import ManageRecord from '@/domains/record/components/manage-record/manage-record';
 import { createPageMetadata } from '@/shared/constants/metadata';
 
 export const metadata = createPageMetadata('manageRecord', { url: '/manage-career' });
 
 export default function Page() {
-  return <CareerRecordTable />;
+  return <ManageRecord recordType="career" />;
 }

--- a/src/app/(main)/(record)/manage-club/page.tsx
+++ b/src/app/(main)/(record)/manage-club/page.tsx
@@ -1,8 +1,8 @@
-import ClubRecordTable from '@/domains/record/components/record-manage/club-record-table';
+import ManageRecord from '@/domains/record/components/manage-record/manage-record';
 import { createPageMetadata } from '@/shared/constants/metadata';
 
 export const metadata = createPageMetadata('manageRecord', { url: '/manage-club' });
 
 export default function Page() {
-  return <ClubRecordTable />;
+  return <ManageRecord recordType="club" />;
 }

--- a/src/app/(main)/(record)/manage-free/page.tsx
+++ b/src/app/(main)/(record)/manage-free/page.tsx
@@ -1,8 +1,8 @@
-import FreeRecordTable from '@/domains/record/components/record-manage/free-record-table';
+import ManageRecord from '@/domains/record/components/manage-record/manage-record';
 import { createPageMetadata } from '@/shared/constants/metadata';
 
 export const metadata = createPageMetadata('manageRecord', { url: '/manage-free' });
 
 export default function Page() {
-  return <FreeRecordTable />;
+  return <ManageRecord recordType="free" />;
 }

--- a/src/app/(main)/(record)/manage-subject/page.tsx
+++ b/src/app/(main)/(record)/manage-subject/page.tsx
@@ -1,8 +1,8 @@
-import SubjectRecordTable from '@/domains/record/components/record-manage/subject-record-table';
+import ManageRecord from '@/domains/record/components/manage-record/manage-record';
 import { createPageMetadata } from '@/shared/constants/metadata';
 
 export const metadata = createPageMetadata('manageRecord', { url: '/manage-subject' });
 
 export default function Page() {
-  return <SubjectRecordTable />;
+  return <ManageRecord recordType="subject" />;
 }

--- a/src/domains/record/apis/infinite-queries/use-get-records.ts
+++ b/src/domains/record/apis/infinite-queries/use-get-records.ts
@@ -1,0 +1,63 @@
+import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
+
+import type {
+  RecordsResponse,
+  GetRecordsParams,
+  RecordsFilters,
+} from '@/domains/record/types/record';
+import { api } from '@/shared/lib/api';
+
+export const getRecords = async (params: GetRecordsParams) => {
+  const searchParams = new URLSearchParams();
+
+  if (params.grade) {
+    searchParams.append('grade', params.grade.toString());
+  }
+
+  if (params.classNumber) {
+    searchParams.append('classNumber', params.classNumber.toString());
+  }
+
+  if (params.search) {
+    searchParams.append('search', params.search);
+  }
+
+  if (params.lastRecordId) {
+    searchParams.append('lastRecordId', params.lastRecordId.toString());
+  }
+
+  const queryString = searchParams.toString();
+  const endpoint = queryString
+    ? `/api/v2/student-records/${params.recordType}?${queryString}`
+    : `/api/v2/student-records/${params.recordType}`;
+
+  return api.get<RecordsResponse>(endpoint);
+};
+
+export const useGetRecords = (filters: RecordsFilters) => {
+  return useInfiniteQuery<
+    RecordsResponse,
+    Error,
+    RecordsResponse,
+    readonly unknown[],
+    number | undefined
+  >({
+    queryKey: ['records', 'infinite', filters],
+    queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
+      getRecords({
+        ...filters,
+        lastRecordId: pageParam,
+      }),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => {
+      const records = lastPage.studentRecords;
+      if (records.length === 0) return undefined;
+      return records[records.length - 1].recordId;
+    },
+    placeholderData: keepPreviousData,
+
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 0,
+  });
+};

--- a/src/domains/record/apis/infinite-queries/use-get-students.ts
+++ b/src/domains/record/apis/infinite-queries/use-get-students.ts
@@ -28,10 +28,6 @@ export const getStudents = async (params: GetStudentsParams = {}) => {
     searchParams.append('lastStudentId', params.lastStudentId.toString());
   }
 
-  if (params.pageSize && params.pageSize !== 20) {
-    searchParams.append('pageSize', params.pageSize.toString());
-  }
-
   const queryString = searchParams.toString();
   const endpoint = queryString ? `/api/v1/students?${queryString}` : '/api/v1/students';
 

--- a/src/domains/record/components/manage-record/manage-record-dashboard-header.tsx
+++ b/src/domains/record/components/manage-record/manage-record-dashboard-header.tsx
@@ -1,0 +1,30 @@
+import { RECORD_TYPE_TITLES } from '@/domains/record/constants/record-type';
+import { type RecordType } from '@/domains/record/types/record';
+
+interface ManageRecordDashboardHeaderProps {
+  recordType: RecordType;
+}
+
+export default function ManageRecordDashboardHeader({
+  recordType,
+}: ManageRecordDashboardHeaderProps) {
+  return (
+    <div className="flex items-center self-stretch bg-gray-1">
+      <div className="flex w-[100px] items-center justify-center px-9 py-4">
+        <span className="text-label-16 text-gray-4">학년</span>
+      </div>
+      <div className="flex w-[100px] items-center justify-center px-10 py-4">
+        <span className="text-label-16 text-gray-4">반</span>
+      </div>
+      <div className="flex w-[200px] items-center justify-center px-10 py-4">
+        <span className="text-label-16 text-gray-4">번호</span>
+      </div>
+      <div className="flex w-[140px] items-center justify-center px-10 py-4">
+        <span className="text-label-16 text-gray-4">이름</span>
+      </div>
+      <div className="flex flex-1 items-center justify-center px-10 py-4">
+        <span className="text-label-16 text-gray-4">{RECORD_TYPE_TITLES[recordType]}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/record/components/manage-record/manage-record-header.tsx
+++ b/src/domains/record/components/manage-record/manage-record-header.tsx
@@ -1,0 +1,26 @@
+import { RECORD_TYPE_TITLES } from '@/domains/record/constants/record-type';
+import { type RecordType } from '@/domains/record/types/record';
+import Button from '@/shared/components/ui/button/button';
+
+interface ManageRecordHeaderProps {
+  recordType: RecordType;
+}
+
+export default function ManageRecordHeader({ recordType }: ManageRecordHeaderProps) {
+  return (
+    <div className="mb-14 flex w-[1135px] items-center justify-between">
+      <h2 className="text-heading-24 text-gray-black">{RECORD_TYPE_TITLES[recordType]}</h2>
+
+      {/* 엑셀 내보내기 api 구현 후 연동 예정 */}
+      <Button
+        color="primary"
+        variant="fill"
+        size="medium"
+        shape="rect"
+        className="text-label-16 text-white"
+      >
+        엑셀로 내보내기
+      </Button>
+    </div>
+  );
+}

--- a/src/domains/record/components/manage-record/manage-record.tsx
+++ b/src/domains/record/components/manage-record/manage-record.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useGetRecords } from '@/domains/record/apis/infinite-queries/use-get-records';
+import type {
+  RecordsResponse,
+  Records,
+  RecordsFilters,
+  RecordType,
+} from '@/domains/record/types/record';
+import { useInfiniteScroll } from '@/shared/hooks/use-infinite-scroll';
+
+import ManageRecordDashboardHeader from './manage-record-dashboard-header';
+import ManageRecordHeader from './manage-record-header';
+import RecordRow from './record-row';
+import SearchBar from './search-bar';
+
+import type { InfiniteData } from '@tanstack/react-query';
+
+interface ManageRecordProps {
+  recordType: RecordType;
+}
+
+export default function ManageRecord({ recordType }: ManageRecordProps) {
+  const [filters, setFilters] = useState<RecordsFilters>({ recordType: recordType });
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } =
+    useGetRecords(filters);
+
+  const lastRecordElementRef = useInfiniteScroll({
+    fetchNextPage,
+    hasNextPage: hasNextPage || false,
+    isFetching: isFetchingNextPage,
+    threshold: 0.1,
+  });
+
+  const infiniteData = data as InfiniteData<RecordsResponse> | undefined;
+  const allRecords: Records[] = infiniteData?.pages.flatMap((page) => page.studentRecords) || [];
+  const totalCount = infiniteData?.pages[0]?.studentCount || 0;
+  const grades = infiniteData?.pages[0]?.grades;
+  const classNumbers = infiniteData?.pages[0]?.classNumbers;
+
+  const handleFiltersChange = (newFilters: RecordsFilters) => {
+    setFilters(newFilters);
+  };
+
+  return (
+    <div className="flex w-full flex-col justify-center p-[60px]">
+      <ManageRecordHeader recordType={recordType} />
+
+      <div className="mb-8 flex w-[1135px] flex-col items-start gap-6">
+        <div className="flex items-center justify-between self-stretch">
+          <h3 className="text-heading-24 text-gray-black">총 {totalCount}명의 학생 등록</h3>
+          <SearchBar
+            recordType={recordType}
+            grades={grades}
+            classNumbers={classNumbers}
+            onFiltersChange={handleFiltersChange}
+          />
+        </div>
+      </div>
+
+      <div className="mb-80 flex w-[1135px] flex-col items-start">
+        <ManageRecordDashboardHeader recordType={recordType} />
+
+        {isLoading ? (
+          <div className="flex w-full items-center justify-center py-8">
+            <div className="text-gray-black">로딩중...</div>
+          </div>
+        ) : error ? (
+          <div className="flex w-full items-center justify-center py-8">
+            <div className="text-red-500">데이터를 불러오는데 실패했습니다.</div>
+          </div>
+        ) : totalCount === 0 ? (
+          <div className="flex w-full items-center justify-center py-8">
+            <div className="text-gray-black">등록된 학생이 없습니다.</div>
+          </div>
+        ) : (
+          <>
+            {allRecords.map((record: Records, index: number) => {
+              const isLast = index === allRecords.length - 1;
+
+              return (
+                <RecordRow
+                  key={record.recordId}
+                  record={record}
+                  forwardRef={isLast ? lastRecordElementRef : undefined}
+                />
+              );
+            })}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/domains/record/components/manage-record/record-row.tsx
+++ b/src/domains/record/components/manage-record/record-row.tsx
@@ -1,0 +1,34 @@
+import type { Records } from '@/domains/record/types/record';
+import { calculateByte } from '@/domains/record/utils/calculate-byte';
+
+interface RecordRowProps {
+  record: Records;
+  forwardRef?: React.Ref<HTMLDivElement>;
+}
+
+export default function RecordRow({ record, forwardRef }: RecordRowProps) {
+  return (
+    <div ref={forwardRef} className="flex items-center self-stretch border-b border-gray-2">
+      <div className="flex w-[100px] items-center justify-center self-stretch border-r border-gray-2 px-9 py-4">
+        <span className="truncate text-body-16-m text-gray-4">{record.grade}</span>
+      </div>
+      <div className="flex w-[100px] items-center justify-center self-stretch border-r border-gray-2 px-9 py-4">
+        <span className="truncate text-body-16-m text-gray-4">{record.classNumber}</span>
+      </div>
+      <div className="flex w-[200px] items-center justify-center self-stretch border-r border-gray-2 px-9 py-4">
+        <span className="truncate text-body-16-m text-gray-4">{record.studentNumber}</span>
+      </div>
+      <div className="flex w-[140px] items-center justify-center self-stretch border-r border-gray-2 px-9 py-4">
+        <span className="truncate text-body-16-m text-gray-4">{record.studentName}</span>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center justify-center gap-[10px] self-stretch px-10 py-4">
+        <p className="text-body-16-m text-gray-black">{record.description}</p>
+        <div className="flex w-full items-center justify-end gap-[2px]">
+          <span className="text-body-16-r text-gray-4">{calculateByte(record.description)}</span>
+          <span className="text-body-16-r text-gray-4">Bytes</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/record/components/manage-record/record-row.tsx
+++ b/src/domains/record/components/manage-record/record-row.tsx
@@ -1,9 +1,11 @@
+import type { Ref } from 'react';
+
 import type { Records } from '@/domains/record/types/record';
 import { calculateByte } from '@/domains/record/utils/calculate-byte';
 
 interface RecordRowProps {
   record: Records;
-  forwardRef?: React.Ref<HTMLDivElement>;
+  forwardRef?: Ref<HTMLDivElement>;
 }
 
 export default function RecordRow({ record, forwardRef }: RecordRowProps) {

--- a/src/domains/record/components/manage-record/search-bar.tsx
+++ b/src/domains/record/components/manage-record/search-bar.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { RecordsFilters, RecordType } from '@/domains/record/types/record';
+import Dropdown from '@/shared/components/ui/dropdown/dropdown';
+import { Icons } from '@/shared/components/ui/icon/icon';
+import { Input } from '@/shared/components/ui/input/input';
+
+interface SearchBarProps {
+  recordType: RecordType;
+  grades?: number[];
+  classNumbers?: number[];
+  onFiltersChange: (filters: RecordsFilters) => void;
+}
+
+export default function SearchBar({
+  recordType,
+  grades,
+  classNumbers,
+  onFiltersChange,
+}: SearchBarProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedGrade, setSelectedGrade] = useState<number | undefined>();
+  const [selectedClassNumber, setSelectedClassNumber] = useState<number | undefined>();
+
+  const updateFilters = (newGrade?: number, newClassNumber?: number, newSearchTerm?: string) => {
+    const filters: RecordsFilters = {
+      recordType,
+      ...(newGrade && { grade: newGrade }),
+      ...(newClassNumber && { classNumber: newClassNumber }),
+      ...(newSearchTerm && { search: newSearchTerm }),
+    };
+    onFiltersChange(filters);
+  };
+
+  const handleGradeSelect = (grade: number) => {
+    setSelectedGrade(grade);
+    setSelectedClassNumber(undefined);
+    updateFilters(grade, undefined, searchTerm);
+  };
+
+  const handleClassSelect = (classNumber: number) => {
+    setSelectedClassNumber(classNumber);
+    updateFilters(selectedGrade, classNumber, searchTerm);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    updateFilters(selectedGrade, selectedClassNumber, value);
+  };
+
+  const resetGradeFilter = () => {
+    setSelectedGrade(undefined);
+    updateFilters(undefined, selectedClassNumber, searchTerm);
+  };
+
+  const resetClassFilter = () => {
+    setSelectedClassNumber(undefined);
+    updateFilters(selectedGrade, undefined, searchTerm);
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      <Dropdown className="flex">
+        <Dropdown.Trigger
+          className="flex min-w-[120px] items-center justify-between rounded-[10px] border border-gray-2 px-4 py-[11px] text-body-16-m text-gray-black"
+          iconPosition="right"
+        >
+          {selectedGrade ? `${selectedGrade}학년` : '학년'}
+        </Dropdown.Trigger>
+        <Dropdown.Content className="max-h-40 overflow-y-auto rounded-[10px]">
+          <Dropdown.Item onClick={resetGradeFilter} index={0} className="px-4 py-[11px]">
+            전체
+          </Dropdown.Item>
+          {grades?.map((grade, index) => (
+            <Dropdown.Item
+              key={grade}
+              onClick={() => handleGradeSelect(grade)}
+              selected={selectedGrade === grade}
+              index={index + 1}
+              className="px-4 py-[11px]"
+            >
+              {grade}학년
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Content>
+      </Dropdown>
+
+      <Dropdown className="flex">
+        <Dropdown.Trigger
+          className="flex min-w-[120px] items-center justify-between rounded-[10px] border border-gray-2 px-4 py-[11px] text-body-16-m text-gray-black"
+          iconPosition="right"
+        >
+          {selectedClassNumber ? `${selectedClassNumber}반` : '반'}
+        </Dropdown.Trigger>
+        <Dropdown.Content className="max-h-40 overflow-y-auto rounded-[10px]">
+          <Dropdown.Item onClick={resetClassFilter} index={0} className="px-4 py-[11px]">
+            전체
+          </Dropdown.Item>
+          {classNumbers?.map((classNumber, index) => (
+            <Dropdown.Item
+              key={classNumber}
+              onClick={() => handleClassSelect(classNumber)}
+              selected={selectedClassNumber === classNumber}
+              index={index + 1}
+              className="px-4 py-[11px]"
+            >
+              {classNumber}반
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Content>
+      </Dropdown>
+
+      <div className="relative">
+        <Input
+          type="text"
+          placeholder="이름"
+          value={searchTerm}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          className="h-[48px] min-w-[200px] rounded-[10px] border border-gray-2 py-[11px] pl-4 pr-10"
+        />
+        <Icons.Search
+          size={20}
+          color="text-gray-4"
+          className="absolute right-3 top-1/2 -translate-y-1/2"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/domains/record/components/manage-student/edit-cell.tsx
+++ b/src/domains/record/components/manage-student/edit-cell.tsx
@@ -69,7 +69,7 @@ export function EditCell({ student, field, value, onSave, className }: EditableC
           className="w-full bg-transparent text-center text-body-16-m text-gray-black outline-none"
         />
       ) : (
-        <span className="text-body-16-m text-gray-black">{value}</span>
+        <span className="truncate text-body-16-m text-gray-black">{value}</span>
       )}
 
       {error ? (

--- a/src/domains/record/components/manage-student/manage-student.tsx
+++ b/src/domains/record/components/manage-student/manage-student.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { useGetStudents } from '@/domains/record/apis/infinite-queries/get-students';
+import { useGetStudents } from '@/domains/record/apis/infinite-queries/use-get-students';
 import type { StudentsResponse, Student, StudentFilters } from '@/domains/record/types/record';
 import { useInfiniteScroll } from '@/shared/hooks/use-infinite-scroll';
 

--- a/src/domains/record/components/manage-student/student-row.tsx
+++ b/src/domains/record/components/manage-student/student-row.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import type { Ref } from 'react';
 
 import { usePatchStudents } from '@/domains/record/apis/mutations/use-patch-students';
 import { RecordTag } from '@/domains/record/components/manage-student/record-tag';
@@ -15,7 +16,7 @@ interface StudentRowProps {
   student: Student;
   isSelected: boolean;
   onToggleSelect: (studentId: number) => void;
-  forwardRef?: React.Ref<HTMLDivElement>;
+  forwardRef?: Ref<HTMLDivElement>;
 }
 
 export function StudentRow({ student, isSelected, onToggleSelect, forwardRef }: StudentRowProps) {

--- a/src/domains/record/components/record-write/student-sidebar-content.tsx
+++ b/src/domains/record/components/record-write/student-sidebar-content.tsx
@@ -161,7 +161,7 @@ export default function StudentSidebarContent({
                   isStudentActive(student.recordId) && 'bg-gray-2',
                 )}
               >
-                <span className="text-label-18 text-gray-black">
+                <span className="block truncate text-label-18 text-gray-black">
                   {`${index + 1}. ${student.studentName}`}
                 </span>
               </button>

--- a/src/domains/record/mocks/get-records.ts
+++ b/src/domains/record/mocks/get-records.ts
@@ -1,58 +1,135 @@
 import { http, HttpResponse } from 'msw';
 
-import { RECORD_DATA } from '@/domains/record/constants/record-data';
-import type { RecordType } from '@/domains/record/types/record';
-import { checkAccessToken } from '@/shared/mocks/utils/check-access-token';
+import type { Records, RecordType } from '@/domains/record/types/record';
+
+const generateMockRecords = (recordType: RecordType): Records[] => {
+  const records: Records[] = [];
+  const descriptions = {
+    subject: [
+      '수학 과목에서 뛰어난 문제해결 능력을 보여주며, 특히 기하학 영역에서 창의적인 접근 방식을 보입니다.',
+      '과학 실험에 적극적으로 참여하며, 가설 설정부터 결과 분석까지 체계적으로 수행합니다.',
+      '국어 수업에서 문학 작품 분석 능력이 우수하며, 토론 활동에서 논리적인 의견을 제시합니다.',
+      '영어 회화 실력이 뛰어나며, 원어민과의 대화에서도 유창하게 소통합니다.',
+    ],
+    behavior: [
+      '친구들과의 관계가 원만하며, 갈등 상황에서 중재 역할을 잘 수행합니다.',
+      '학급 활동에 적극적으로 참여하며, 리더십을 발휘하여 모둠을 이끌어 갑니다.',
+      '규칙을 잘 지키며, 다른 학생들에게 모범이 되는 행동을 보입니다.',
+      '어려움에 처한 친구들을 도와주며, 배려심이 깊은 학생입니다.',
+    ],
+    career: [
+      '진로에 대한 확고한 목표를 가지고 있으며, 관련 활동에 적극적으로 참여합니다.',
+      '직업 체험 활동에서 성실한 태도로 임무를 수행하며, 전문가와의 인터뷰를 통해 진로 탐색에 노력합니다.',
+      '자신의 적성과 흥미를 파악하기 위해 다양한 진로 검사에 참여하고 결과를 분석합니다.',
+    ],
+    free: [
+      '독서 활동을 꾸준히 하며, 다양한 장르의 책을 읽고 감상문을 작성합니다.',
+      '예술 활동에 관심이 많으며, 학교 축제에서 창작 작품을 발표합니다.',
+      '봉사 활동에 적극적으로 참여하며, 지역 사회에 기여하고자 하는 의지가 강합니다.',
+    ],
+    club: [
+      '동아리 활동에서 부장으로서 책임감 있게 활동을 이끌어 갑니다.',
+      '과학 동아리에서 실험 설계부터 발표까지 전 과정에 참여하며 우수한 성과를 거둡니다.',
+      '문예 동아리에서 창작 활동을 하며, 교내 문예지에 작품을 게재합니다.',
+    ],
+  };
+
+  for (let i = 1; i <= 150; i++) {
+    const grade = Math.floor((i - 1) / 50) + 1;
+    const classNumber = Math.floor(((i - 1) % 50) / 10) + 1;
+    const studentNumber = ((i - 1) % 10) + 1;
+
+    records.push({
+      recordId: i,
+      grade,
+      classNumber,
+      studentNumber,
+      studentName: `학생${i}`,
+      description: descriptions[recordType][i % descriptions[recordType].length],
+    });
+  }
+
+  return records;
+};
+
+const MOCK_RECORDS: Record<RecordType, Records[]> = {
+  subject: generateMockRecords('subject'),
+  behavior: generateMockRecords('behavior'),
+  career: generateMockRecords('career'),
+  free: generateMockRecords('free'),
+  club: generateMockRecords('club'),
+};
+
+const getAllGrades = (): number[] => {
+  const grades = new Set<number>();
+  Object.values(MOCK_RECORDS).forEach((records) => {
+    records.forEach((record) => grades.add(record.grade));
+  });
+  return Array.from(grades).sort();
+};
+
+const getAllClassNumbers = (): number[] => {
+  const classNumbers = new Set<number>();
+  Object.values(MOCK_RECORDS).forEach((records) => {
+    records.forEach((record) => classNumbers.add(record.classNumber));
+  });
+  return Array.from(classNumbers).sort();
+};
 
 export const getRecords = [
-  http.get<never, { recordType: RecordType }>(
-    '/api/v1/student-records/:recordType',
-    ({ params, request }) => {
-      const authHeader = request.headers.get('Authorization');
+  http.get('/api/v2/student-records/:recordType', ({ request, params }) => {
+    const { recordType } = params;
+    const url = new URL(request.url);
 
-      const validation = checkAccessToken(authHeader);
+    const grade = url.searchParams.get('grade');
+    const classNumber = url.searchParams.get('classNumber');
+    const search = url.searchParams.get('search');
+    const lastRecordId = url.searchParams.get('lastRecordId');
+    const pageSize = 20;
 
-      if (!validation.isValid) {
-        return HttpResponse.json(
-          {
-            code: 'A-40101',
-            message: '토큰이 누락되었습니다.',
-          },
-          { status: 200 },
-        );
-      }
+    let filteredRecords = [...MOCK_RECORDS[recordType as RecordType]];
 
-      if (validation.isExpired) {
-        return HttpResponse.json(
-          {
-            code: 'A-40101',
-            message: '토큰이 누락되었습니다.',
-          },
-          { status: 200 },
-        );
-      }
+    if (grade) {
+      filteredRecords = filteredRecords.filter((record) => record.grade === parseInt(grade));
+    }
 
-      if (validation.isNotVerified) {
-        return HttpResponse.json(
-          {
-            code: 'A-40304',
-            message: '접근 권한이 없는 사용자입니다. 교사 인증을 진행해주세요.',
-          },
-          { status: 200 },
-        );
-      }
-      const { recordType } = params;
-
-      const records = RECORD_DATA[recordType];
-
-      return HttpResponse.json(
-        {
-          code: 'SUCCESS',
-          message: '요청이 성공했습니다.',
-          data: records,
-        },
-        { status: 200 },
+    if (classNumber) {
+      filteredRecords = filteredRecords.filter(
+        (record) => record.classNumber === parseInt(classNumber),
       );
-    },
-  ),
+    }
+
+    if (search) {
+      filteredRecords = filteredRecords.filter(
+        (record) =>
+          record.studentName.includes(search) ||
+          record.description.includes(search) ||
+          record.studentNumber.toString().includes(search),
+      );
+    }
+
+    let startIndex = 0;
+    if (lastRecordId) {
+      const lastIndex = filteredRecords.findIndex(
+        (record) => record.recordId === parseInt(lastRecordId),
+      );
+      startIndex = lastIndex + 1;
+    }
+
+    const paginatedRecords = filteredRecords.slice(startIndex, startIndex + pageSize);
+
+    return HttpResponse.json(
+      {
+        code: 'SUCCESS',
+        message: '요청이 성공했습니다.',
+        data: {
+          studentCount: filteredRecords.length,
+          grades: getAllGrades(),
+          classNumbers: getAllClassNumbers(),
+          studentRecords: paginatedRecords,
+        },
+      },
+      { status: 200 },
+    );
+  }),
 ];

--- a/src/domains/record/mocks/get-students.ts
+++ b/src/domains/record/mocks/get-students.ts
@@ -46,7 +46,7 @@ export const getStudents = [
     const classNumbers = url.searchParams.getAll('classNumbers').map(Number);
     const recordTypes = url.searchParams.getAll('recordTypes') as RecordType[];
     const lastStudentId = url.searchParams.get('lastStudentId');
-    const pageSize = parseInt(url.searchParams.get('pageSize') || '20');
+    const pageSize = 20;
 
     let filteredStudents = [...MOCK_STUDENTS];
 

--- a/src/domains/record/types/record.ts
+++ b/src/domains/record/types/record.ts
@@ -125,6 +125,7 @@ export interface CreateStudentRequest {
   studentName: string;
   recordTypes: RecordType[];
 }
+
 export interface StudentsResponse {
   studentCount: number;
   grades: number[];
@@ -140,5 +141,31 @@ export interface StudentFilters {
 
 export interface GetStudentsParams extends StudentFilters {
   lastStudentId?: number;
-  pageSize?: number;
+}
+
+export interface Records {
+  recordId: number;
+  grade: number;
+  classNumber: number;
+  studentNumber: number;
+  studentName: string;
+  description: string;
+}
+
+export interface RecordsResponse {
+  studentCount: number;
+  grades: number[];
+  classNumbers: number[];
+  studentRecords: Records[];
+}
+
+export interface RecordsFilters {
+  recordType: RecordType;
+  grade?: number;
+  classNumber?: number;
+  search?: string;
+}
+
+export interface GetRecordsParams extends RecordsFilters {
+  lastRecordId?: number;
 }


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-424]

## 🌱 주요 변경 사항

1. 생활기록부 목록 받아오는 무한스크롤 api 훅 구현 및 msw 코드 작성
2. ManageRecordHeader 컴포넌트 구현
3. ManageRecordDashboardHeader 컴포넌트 구현
4. 필터 기능 및 검색 기능을 담당하고 그에 따른 데이터를 보여주는 SearchBar 컴포넌트 구현
5. 생활기록부 개별 행인 RecordRow 컴포넌트 구현
6. ManageRecord 컴포넌트 구현 및 무한 스크롤 api 연동
7. 생활기록부 관리 page.tsx에서 ManageRecord컴포넌트로 교체
8. 생활기록부 관리 로직에 필요한 type들 정의
9. 이름이 너무 길어서 UI가 깨지는 컴포넌트에 truncate 속성 적용
10. 학생 목록 받아오는 무한스크롤 api 파일명 수정에 따른 리팩토링

## 📸 스크린샷 (선택)
<img width="1709" height="860" alt="스크린샷 2025-09-10 오후 12 24 42" src="https://github.com/user-attachments/assets/9967c05b-b78b-4646-ba50-2c8baca28327" />

<img width="1709" height="860" alt="스크린샷 2025-09-10 오후 12 25 07" src="https://github.com/user-attachments/assets/a5b258c1-9732-4223-8005-0267aad0df47" />


[EDMT-424]: https://bbangbbangz.atlassian.net/browse/EDMT-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 기록 관리 화면을 단일 컴포넌트로 통합하고 학년/반/이름 필터, 검색, 무한 스크롤 목록 제공
  * 각 기록 유형(과목·행동·진로·자율·동아리) 페이지에 공통 UI 적용 및 엑셀 내보내기 버튼 노출(추후 연동)

* 리팩터
  * 개별 테이블 구현을 공통 ManageRecord 컴포넌트로 교체

* 스타일
  * 사이드바 및 목록의 긴 텍스트 말줄임 처리 적용

* 기타
  * 모의 API를 필터·검색·커서 기반 페이징으로 개편 및 관련 타입/응답 구조 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->