### PR TITLE
[EDMT-434] 학생 관리 페이지 테스트 코드 작성 및 icon, 인터섹션 옵저버를 위한 jest 설정 추가

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,6 +33,7 @@ const config: Config = {
   // 모듈 경로 매핑
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.svg$': '<rootDir>/src/__tests__/mocks/svg.tsx',
   },
 
   // 테스트 파일 패턴

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,9 +1,23 @@
+import React from 'react';
+
 import '@testing-library/jest-dom';
+
 import { setupMSW } from '@/__tests__/utils/msw-setup';
 
 // 테스트 환경에서 MSW 활성화
 process.env.NEXT_PUBLIC_API_MOCKING = 'enabled';
 setupMSW();
+
+// IntersectionObserver Mock
+global.IntersectionObserver = jest.fn((_callback) => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+  takeRecords: jest.fn(),
+  root: null,
+  rootMargin: '',
+  thresholds: [],
+}));
 
 // Next.js useRouter Mock
 const mockPush = jest.fn();
@@ -42,6 +56,48 @@ jest.mock('@/shared/providers/auth-provider', () => ({
 (global as any).mockRefresh = mockRefresh;
 (global as any).mockSetAuthData = mockSetAuthData;
 (global as any).mockUseAuth = mockUseAuth;
+
+// SVG 파일 모킹
+jest.mock('@/shared/components/ui/icon/icon', () => {
+  const MockIcon = React.forwardRef<SVGSVGElement, any>((props: any, ref: any) => {
+    const { hoverColor, color, ...validProps } = props;
+    return React.createElement('svg', { ref, ...validProps });
+  });
+  MockIcon.displayName = 'MockIcon';
+
+  return {
+    Icons: {
+      Add: MockIcon,
+      Close: MockIcon,
+      Check: MockIcon,
+      BoxDefault: MockIcon,
+      BoxChecked: MockIcon,
+      Upload: MockIcon,
+      Download: MockIcon,
+      ChevronUp: MockIcon,
+      ChevronDown: MockIcon,
+      Filter: MockIcon,
+      Logo: MockIcon,
+      Search: MockIcon,
+      SidebarClose: MockIcon,
+      Copy: MockIcon,
+    },
+    Add: MockIcon,
+    Close: MockIcon,
+    Check: MockIcon,
+    BoxDefault: MockIcon,
+    BoxChecked: MockIcon,
+    Upload: MockIcon,
+    Download: MockIcon,
+    ChevronUp: MockIcon,
+    ChevronDown: MockIcon,
+    Filter: MockIcon,
+    Logo: MockIcon,
+    Search: MockIcon,
+    SidebarClose: MockIcon,
+    Copy: MockIcon,
+  };
+});
 
 // 전역으로 mock을 초기화 할 수 있는 함수
 (global as any).clearAllTestMocks = () => {

--- a/src/domains/record/__tests__/manage-student.test.tsx
+++ b/src/domains/record/__tests__/manage-student.test.tsx
@@ -520,9 +520,7 @@ describe('ManageStudent 컴포넌트 단위 테스트', () => {
         await user.click(subjectOption);
       }
 
-      const saveButton =
-        screen.getByRole('button', { name: '추가' }) ||
-        screen.getByRole('button', { name: '저장' });
+      const saveButton = screen.getByRole('button', { name: '추가' });
 
       await user.click(saveButton);
 
@@ -542,9 +540,7 @@ describe('ManageStudent 컴포넌트 단위 테스트', () => {
         expect(inputs).toHaveLength(4);
       });
 
-      const saveButton =
-        screen.getByRole('button', { name: '추가' }) ||
-        screen.getByRole('button', { name: '저장' });
+      const saveButton = screen.getByRole('button', { name: '추가' });
 
       await user.click(saveButton);
 

--- a/src/domains/record/__tests__/manage-student.test.tsx
+++ b/src/domains/record/__tests__/manage-student.test.tsx
@@ -1,0 +1,657 @@
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render, loginAsUser } from '@/__tests__/utils/test-utils';
+import ManageStudent from '@/domains/record/components/manage-student/manage-student';
+
+global.alert = jest.fn();
+global.confirm = jest.fn();
+
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => 'mock-url');
+  global.URL.revokeObjectURL = jest.fn();
+
+  global.Blob = jest.fn((parts, options) => ({
+    size: 0,
+    type: options?.type || '',
+    parts,
+  })) as any;
+
+  const originalCreateElement = document.createElement;
+  document.createElement = jest.fn((tagName) => {
+    if (tagName === 'a') {
+      const mockAnchor = originalCreateElement.call(document, 'a');
+      mockAnchor.click = jest.fn();
+      mockAnchor.dispatchEvent = jest.fn();
+      return mockAnchor;
+    }
+    return originalCreateElement.call(document, tagName);
+  });
+});
+
+describe('ManageStudent 컴포넌트 단위 테스트', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(async () => {
+    user = userEvent.setup();
+    clearAllTestMocks();
+    (global.alert as jest.Mock).mockClear();
+    (global.confirm as jest.Mock).mockClear();
+    (global.URL.createObjectURL as jest.Mock).mockClear();
+
+    await loginAsUser();
+  });
+
+  describe('기본 렌더링 테스트', () => {
+    it('컴포넌트가 정상적으로 렌더링된다', async () => {
+      render(<ManageStudent />);
+
+      expect(screen.getByText('학생 관리')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '학생 추가' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '엑셀 파일에서 명단 업로드' })).toBeInTheDocument();
+      expect(screen.getByText('필터')).toBeInTheDocument();
+    });
+
+    it('학생 데이터 로딩 후 학생 목록을 표시한다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총.*명의 학생 등록/)).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('학생 목록 표시 테스트', () => {
+    it('학생 목록 헤더가 정상적으로 표시된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        const headers = screen.getAllByText('학년');
+        expect(headers.length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('반').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('번호')).toBeInTheDocument();
+        expect(screen.getByText('이름')).toBeInTheDocument();
+        expect(screen.getByText('생활기록부 관리 항목')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('학생 선택 및 삭제 기능 테스트', () => {
+    it('개별 학생 체크박스를 클릭하면 선택된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const firstStudentCheckbox = screen.getAllByTestId('student-defaultbox')[0];
+      expect(firstStudentCheckbox).toBeInTheDocument();
+
+      await user.click(firstStudentCheckbox);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총.*명의 학생 선택/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '삭제' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+      });
+
+      const selectionText = screen.getByText(/총.*명의 학생 선택/).textContent;
+      expect(selectionText).toMatch(/총 1명의 학생 선택/);
+    });
+
+    it('여러 학생을 선택할 수 있다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const studentCheckboxes = screen.getAllByTestId('student-defaultbox');
+
+      await user.click(studentCheckboxes[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총 1명의 학생 선택/)).toBeInTheDocument();
+      });
+
+      await user.click(studentCheckboxes[1]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총 2명의 학생 선택/)).toBeInTheDocument();
+      });
+
+      await user.click(studentCheckboxes[2]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총 3명의 학생 선택/)).toBeInTheDocument();
+      });
+    });
+
+    it('전체 선택 체크박스를 클릭하면 모든 학생이 선택된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const headerCheckbox = screen.getByTestId('header-defaultbox');
+      expect(headerCheckbox).toBeInTheDocument();
+
+      await user.click(headerCheckbox);
+
+      await waitFor(() => {
+        const selectionText = screen.getByText(/총.*명의 학생 선택/).textContent;
+        const selectedCount = parseInt(selectionText?.match(/\d+/)?.[0] || '0');
+
+        expect(selectedCount).toBeGreaterThan(0);
+      });
+    });
+
+    it('취소 버튼을 클릭하면 모든 선택이 해제된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const firstStudentCheckbox = screen.getAllByTestId('student-defaultbox')[0];
+      await user.click(firstStudentCheckbox);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총.*명의 학생 선택/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: '취소' });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/총.*명의 학생 선택/)).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: '삭제' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: '취소' })).not.toBeInTheDocument();
+
+        expect(screen.getByText(/총.*명의 학생 등록/)).toBeInTheDocument();
+      });
+    });
+
+    it('삭제 버튼을 클릭하면 삭제 확인 모달이 열린다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const firstStudentCheckbox = screen.getAllByTestId('student-defaultbox')[0];
+      await user.click(firstStudentCheckbox);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '삭제' })).toBeInTheDocument();
+      });
+
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('정말 삭제하시겠습니까?')).toBeInTheDocument();
+        expect(
+          screen.getByText('현재까지 작성한 학생들의 생활기록부 내용이 사라집니다.'),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId('modal-remove-button')).toBeInTheDocument();
+      });
+    });
+
+    it('삭제 확인 모달에서 취소를 클릭하면 모달이 닫힌다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const firstStudentCheckbox = screen.getAllByTestId('student-defaultbox')[0];
+      await user.click(firstStudentCheckbox);
+
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const confirmCancelButton = screen.getByTestId('modal-cancel-button');
+      await user.click(confirmCancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.queryByText('정말 삭제하시겠습니까?')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/총.*명의 학생 선택/)).toBeInTheDocument();
+    });
+
+    it('삭제 확인 모달에서 삭제를 클릭하면 모달이 사라진다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('학생1')).toBeInTheDocument();
+      });
+
+      const firstStudentCheckbox = screen.getAllByTestId('student-defaultbox')[0];
+      await user.click(firstStudentCheckbox);
+
+      const deleteButton = screen.getByRole('button', { name: '삭제' });
+      await user.click(deleteButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('modal-remove-button')).toBeInTheDocument();
+      });
+
+      const confirmDeleteButton = screen.getByTestId('modal-remove-button');
+      await user.click(confirmDeleteButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.queryByText(/총.*명의 학생 선택/)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('필터 기능 테스트', () => {
+    it('필터 버튼을 클릭하면 메뉴가 표시된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('필터')).toBeInTheDocument();
+      });
+
+      const filterButton = screen.getByText('필터').closest('button');
+      if (filterButton) {
+        await user.click(filterButton);
+
+        await waitFor(() => {
+          expect(screen.getByRole('option', { name: '학년' })).toBeInTheDocument();
+          expect(screen.getByRole('option', { name: '반' })).toBeInTheDocument();
+          expect(screen.getByRole('option', { name: '생기부 관리 항목' })).toBeInTheDocument();
+        });
+      }
+    });
+
+    it('학년 필터를 선택하면 해당 학년 학생들만 표시된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/총.*명의 학생 등록/)).toBeInTheDocument();
+      });
+
+      const filterButton = screen.getByText('필터').closest('button');
+      if (filterButton) {
+        await user.click(filterButton);
+
+        await waitFor(() => {
+          expect(screen.getByRole('option', { name: '학년' })).toBeInTheDocument();
+        });
+
+        const gradeFilter = screen.getByRole('option', { name: '학년' });
+        await user.click(gradeFilter);
+
+        await waitFor(() => {
+          expect(screen.getByText(/학년:/)).toBeInTheDocument();
+        });
+
+        const firstGradeOption = screen.getByRole('option', { name: '1' });
+        await user.click(firstGradeOption);
+
+        await waitFor(() => {
+          expect(screen.getByText('학년: 1')).toBeInTheDocument();
+        });
+
+        await waitFor(() => {
+          const studentRows = screen.getAllByText(/학생\d+/);
+          expect(studentRows.length).toBeGreaterThan(0);
+        });
+      }
+    });
+
+    it('반 필터를 선택하면 해당 반 학생들만 표시된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('필터')).toBeInTheDocument();
+      });
+
+      const filterButton = screen.getByText('필터').closest('button');
+      if (filterButton) {
+        await user.click(filterButton);
+
+        await waitFor(() => {
+          expect(screen.getByRole('option', { name: '반' })).toBeInTheDocument();
+        });
+
+        const classFilter = screen.getByRole('option', { name: '반' });
+        await user.click(classFilter);
+
+        await waitFor(() => {
+          expect(screen.getByText(/반:/)).toBeInTheDocument();
+        });
+
+        const firstClassOption = screen.getByRole('option', { name: '1' });
+        await user.click(firstClassOption);
+
+        await waitFor(() => {
+          expect(screen.getByText('반: 1')).toBeInTheDocument();
+        });
+
+        await waitFor(() => {
+          const studentRows = screen.getAllByText(/학생\d+/);
+          expect(studentRows.length).toBeGreaterThan(0);
+        });
+      }
+    });
+
+    it('생활기록부 관리 항목 필터를 선택하면 해당 항목을 가진 학생들만 표시된다', async () => {
+      render(<ManageStudent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('필터')).toBeInTheDocument();
+      });
+
+      const filterButton = screen.getByText('필터').closest('button');
+      if (filterButton) {
+        await user.click(filterButton);
+
+        await waitFor(() => {
+          expect(screen.getByRole('option', { name: '생기부 관리 항목' })).toBeInTheDocument();
+        });
+
+        const recordFilter = screen.getByRole('option', { name: '생기부 관리 항목' });
+        await user.click(recordFilter);
+
+        await waitFor(() => {
+          expect(screen.getByText(/생활기록부 관리 항목:/)).toBeInTheDocument();
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId('record-option-subject')).toBeInTheDocument();
+        });
+
+        const subjectOption = screen.getByTestId('record-option-subject');
+
+        await user.click(subjectOption);
+
+        await waitFor(() => {
+          const studentRows = screen.getAllByText(/학생\d+/);
+          expect(studentRows.length).toBeGreaterThan(0);
+
+          const subjectTags = screen.getAllByText('세특');
+          expect(subjectTags.length).toBeGreaterThan(1);
+        });
+      }
+    });
+  });
+
+  describe('학생 추가 기능 테스트', () => {
+    it('학생 추가 버튼을 클릭하면 추가 폼이 표시된다', async () => {
+      render(<ManageStudent />);
+
+      const addButton = screen.getByRole('button', { name: '학생 추가' });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText('입력');
+        expect(inputs).toHaveLength(4);
+      });
+
+      expect(addButton).toBeDisabled();
+    });
+
+    it('학생 추가 폼에서 취소할 수 있다', async () => {
+      render(<ManageStudent />);
+
+      const addButton = screen.getByRole('button', { name: '학생 추가' });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText('입력');
+        expect(inputs).toHaveLength(4);
+      });
+
+      const cancelButton = screen.getByRole('button', { name: '취소' });
+      await user.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryAllByPlaceholderText('입력')).toHaveLength(0);
+      });
+
+      expect(addButton).toBeEnabled();
+    });
+
+    it('학생 정보를 입력하고 생활기록부 항목을 선택한 후 입력한후 추가버튼을 누르면 학생 추가 form이 사라진다', async () => {
+      render(<ManageStudent />);
+
+      const addButton = screen.getByRole('button', { name: '학생 추가' });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText('입력');
+        expect(inputs).toHaveLength(4);
+      });
+
+      const inputs = screen.getAllByPlaceholderText('입력');
+      const gradeInput = inputs[0];
+      const classInput = inputs[1];
+      const numberInput = inputs[2];
+      const nameInput = inputs[3];
+
+      await user.type(gradeInput, '2');
+      await user.type(classInput, '3');
+      await user.type(numberInput, '15');
+      await user.type(nameInput, '테스트학생');
+
+      const recordDropdownTrigger = screen.getAllByText('항목 추가')[0].closest('button');
+
+      if (recordDropdownTrigger) {
+        await user.click(recordDropdownTrigger);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('record-option-subject')).toBeInTheDocument();
+          expect(screen.getByTestId('record-option-behavior')).toBeInTheDocument();
+        });
+
+        const subjectOption = screen.getByTestId('record-option-subject');
+        const behaviorOption = screen.getByTestId('record-option-behavior');
+
+        await user.click(subjectOption);
+        await user.click(behaviorOption);
+
+        await waitFor(() => {
+          const subjectTags = screen.getAllByText('세특');
+          const behaviorTags = screen.getAllByText('행발');
+          expect(subjectTags.length).toBeGreaterThan(0);
+          expect(behaviorTags.length).toBeGreaterThan(0);
+        });
+      }
+
+      const saveButton = screen.getByRole('button', { name: '추가' });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(screen.queryAllByPlaceholderText('입력')).toHaveLength(0);
+        expect(addButton).toBeEnabled();
+      });
+    });
+
+    it('중복 학생 등록 시 에러 알림이 표시된다', async () => {
+      render(<ManageStudent />);
+
+      const addButton = screen.getByRole('button', { name: '학생 추가' });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText('입력');
+        expect(inputs).toHaveLength(4);
+      });
+
+      const inputs = screen.getAllByPlaceholderText('입력');
+      const gradeInput = inputs[0];
+      const classInput = inputs[1];
+      const numberInput = inputs[2];
+      const nameInput = inputs[3];
+
+      await user.type(gradeInput, '1');
+      await user.type(classInput, '1');
+      await user.type(numberInput, '1');
+      await user.type(nameInput, '중복학생');
+
+      const recordDropdownTrigger = screen.getAllByText('항목 추가')[0].closest('button');
+
+      if (recordDropdownTrigger) {
+        await user.click(recordDropdownTrigger);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('record-option-subject')).toBeInTheDocument();
+        });
+
+        const subjectOption = screen.getByTestId('record-option-subject');
+        await user.click(subjectOption);
+      }
+
+      const saveButton =
+        screen.getByRole('button', { name: '추가' }) ||
+        screen.getByRole('button', { name: '저장' });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(global.alert).toHaveBeenCalledWith('이미 등록된 학생입니다.');
+      });
+    });
+
+    it('필수 입력값이 없으면 적절한 알림이 표시된다', async () => {
+      render(<ManageStudent />);
+
+      const addButton = screen.getByRole('button', { name: '학생 추가' });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText('입력');
+        expect(inputs).toHaveLength(4);
+      });
+
+      const saveButton =
+        screen.getByRole('button', { name: '추가' }) ||
+        screen.getByRole('button', { name: '저장' });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(global.alert).toHaveBeenCalledWith('학년을 입력해주세요.');
+      });
+    });
+  });
+
+  describe('엑셀 업로드 기능 테스트', () => {
+    const createTestExcelFile = () => {
+      const csvContent =
+        'data:text/csv;charset=utf-8,학년,반,번호,이름\n1,1,1,홍길동\n1,1,2,김철수\n1,1,3,이영희';
+      const blob = new Blob([csvContent], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+      return new File([blob], 'test-students.xlsx', {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+    };
+
+    it('엑셀 업로드 버튼을 클릭하면 모달이 열린다', async () => {
+      render(<ManageStudent />);
+
+      const excelButton = screen.getByRole('button', { name: '엑셀 파일에서 명단 업로드' });
+      await user.click(excelButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('템플릿을 다운로드하여 학생 정보를 입력한 후 업로드해주세요.'),
+        ).toBeInTheDocument();
+        expect(screen.getByText('1단계: 템플릿 다운로드')).toBeInTheDocument();
+        expect(screen.getByText('2단계: 파일 업로드')).toBeInTheDocument();
+        expect(screen.getByText('템플릿 다운로드')).toBeInTheDocument();
+        expect(screen.getByText('드래그하거나 클릭하여 파일 업로드')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '학생 리스트 생성' })).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('button', { name: '학생 리스트 생성' })).toBeDisabled();
+    });
+
+    it('템플릿 다운로드 버튼을 클릭하면 템플릿 파일이 다운로드된다', async () => {
+      render(<ManageStudent />);
+
+      const excelButton = screen.getByRole('button', { name: '엑셀 파일에서 명단 업로드' });
+      await user.click(excelButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('템플릿 다운로드')).toBeInTheDocument();
+      });
+
+      const downloadButton = screen.getByText('템플릿 다운로드');
+      await user.click(downloadButton);
+
+      await waitFor(() => {
+        expect(global.URL.createObjectURL).toHaveBeenCalled();
+      });
+    });
+
+    it('유효한 엑셀 파일을 선택하면 파일이 업로드된다', async () => {
+      render(<ManageStudent />);
+
+      const excelButton = screen.getByRole('button', { name: '엑셀 파일에서 명단 업로드' });
+      await user.click(excelButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('excel-upload')).toBeInTheDocument();
+      });
+
+      const testFile = createTestExcelFile();
+      const hiddenFileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      if (hiddenFileInput) {
+        await user.upload(hiddenFileInput, testFile);
+
+        await waitFor(() => {
+          expect(screen.getByText('test-students.xlsx')).toBeInTheDocument();
+          expect(screen.getByRole('button', { name: '학생 리스트 생성' })).toBeEnabled();
+        });
+      }
+    });
+
+    it('유효한 파일로 학생 리스트를 생성하면 성공 메시지와 함께 모달이 닫힌다', async () => {
+      render(<ManageStudent />);
+
+      const excelButton = screen.getByRole('button', { name: '엑셀 파일에서 명단 업로드' });
+      await user.click(excelButton);
+
+      const testFile = createTestExcelFile();
+      const hiddenFileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      if (hiddenFileInput) {
+        fireEvent.change(hiddenFileInput, { target: { files: [testFile] } });
+
+        await waitFor(() => {
+          expect(screen.getByText('test-students.xlsx')).toBeInTheDocument();
+        });
+
+        const createButton = screen.getByRole('button', { name: '학생 리스트 생성' });
+        await user.click(createButton);
+
+        await waitFor(() => {
+          expect(
+            screen.queryByText('템플릿을 다운로드하여 학생 정보를 입력한 후 업로드해주세요.'),
+          ).not.toBeInTheDocument();
+        });
+      }
+    });
+  });
+});

--- a/src/domains/record/components/manage-student/add-student-row.tsx
+++ b/src/domains/record/components/manage-student/add-student-row.tsx
@@ -170,7 +170,11 @@ export function AddStudentRow({ onCancel }: AddStudentProps) {
                 const isSelected = recordTypes.includes(option.value);
 
                 return (
-                  <div key={option.value} className="flex cursor-pointer items-center px-3 py-2">
+                  <div
+                    key={option.value}
+                    className="flex cursor-pointer items-center px-3 py-2"
+                    data-testid={`record-option-${option.value}`}
+                  >
                     <RecordTag
                       recordType={option.value}
                       showClose={isSelected}

--- a/src/domains/record/components/manage-student/dashboard-header.tsx
+++ b/src/domains/record/components/manage-student/dashboard-header.tsx
@@ -13,9 +13,13 @@ export function DashboardHeader({ isAllSelected, onToggleAll }: DashboardHeaderP
         onClick={onToggleAll}
       >
         {isAllSelected ? (
-          <Icons.BoxChecked color="text-blue-400" />
+          <Icons.BoxChecked color="text-blue-400" data-testid="header-checkbox" />
         ) : (
-          <Icons.BoxDefault color="text-gray-2" hoverColor="text-gray-5" />
+          <Icons.BoxDefault
+            color="text-gray-2"
+            hoverColor="text-gray-5"
+            data-testid="header-defaultbox"
+          />
         )}
       </div>
       <div className="flex w-[100px] items-center justify-center px-9 py-4">

--- a/src/domains/record/components/manage-student/filter-section.tsx
+++ b/src/domains/record/components/manage-student/filter-section.tsx
@@ -253,6 +253,7 @@ export function FilterSection({
                   size={18}
                   color="text-blue-400"
                   hoverColor="text-blue-600"
+                  data-testid="remove-filter"
                   className={`hidden cursor-pointer ${selectedGrades.length > 0 ? 'group-data-[state=closed]:block' : ''}`}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -264,6 +265,7 @@ export function FilterSection({
                 {grades?.map((grade) => (
                   <div
                     key={grade}
+                    role="option"
                     className="flex w-full cursor-pointer items-center rounded-[8px] px-3 py-2 hover:bg-gray-1"
                     onClick={() => handleGradeToggle(grade)}
                   >
@@ -298,6 +300,7 @@ export function FilterSection({
                   size={18}
                   color="text-blue-400"
                   hoverColor="text-blue-600"
+                  data-testid="remove-filter"
                   className={`hidden cursor-pointer ${selectedClasses.length > 0 ? 'group-data-[state=closed]:block' : ''}`}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -310,6 +313,7 @@ export function FilterSection({
                   <div
                     key={classNumber}
                     className="flex w-full cursor-pointer items-center rounded-[8px] px-3 py-2 hover:bg-gray-1"
+                    role="option"
                     onClick={() => handleClassToggle(classNumber)}
                   >
                     <span className="w-[39px] truncate text-body-16-m text-gray-black">
@@ -331,7 +335,7 @@ export function FilterSection({
             >
               <Dropdown.Trigger className="group flex items-center justify-center gap-2 rounded-full bg-blue-50 px-3 py-1.5">
                 <span className="text-label-16 text-blue-400">
-                  생활기록부 관리 항목: {getFilterDisplayText('record')}
+                  {`생활기록부 관리 항목: ${getFilterDisplayText('record')}`}
                 </span>
                 <Icons.ChevronUp
                   size={18}
@@ -343,6 +347,7 @@ export function FilterSection({
                   size={18}
                   color="text-blue-400"
                   hoverColor="text-blue-600"
+                  data-testid="remove-filter"
                   className={`hidden cursor-pointer ${selectedRecordTypes.length > 0 ? 'group-data-[state=closed]:block' : ''}`}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -355,7 +360,12 @@ export function FilterSection({
                   const isSelected = selectedRecordTypes.includes(option.value);
 
                   return (
-                    <div key={option.value} className="flex cursor-pointer items-center px-3 py-2">
+                    <div
+                      key={option.value}
+                      className="flex cursor-pointer items-center px-3 py-2"
+                      role="option"
+                      data-testid={`record-option-${option.value}`}
+                    >
                       <RecordTag
                         recordType={option.value}
                         showClose={isSelected}

--- a/src/domains/record/components/manage-student/student-row.tsx
+++ b/src/domains/record/components/manage-student/student-row.tsx
@@ -98,9 +98,13 @@ export function StudentRow({ student, isSelected, onToggleSelect, forwardRef }: 
         onClick={() => onToggleSelect(student.studentId)}
       >
         {isSelected ? (
-          <Icons.BoxChecked color="text-blue-400" />
+          <Icons.BoxChecked color="text-blue-400" data-testid="student-checkbox" />
         ) : (
-          <Icons.BoxDefault color="text-gray-2" hoverColor="text-gray-5" />
+          <Icons.BoxDefault
+            color="text-gray-2"
+            hoverColor="text-gray-5"
+            data-testid="student-defaultbox"
+          />
         )}
       </div>
 

--- a/src/domains/record/mocks/get-students.ts
+++ b/src/domains/record/mocks/get-students.ts
@@ -76,12 +76,17 @@ export const getStudents = [
 
     const paginatedStudents = filteredStudents.slice(startIndex, startIndex + pageSize);
 
+    const availableGrades = [...new Set(MOCK_STUDENTS.map((s) => s.grade))].sort();
+    const availableClasses = [...new Set(MOCK_STUDENTS.map((s) => s.classNumber))].sort();
+
     return HttpResponse.json(
       {
         code: 'SUCCESS',
         message: '요청이 성공했습니다.',
         data: {
           studentCount: filteredStudents.length,
+          grades: availableGrades,
+          classNumbers: availableClasses,
           students: paginatedStudents,
         },
       },

--- a/src/domains/record/mocks/get-students.ts
+++ b/src/domains/record/mocks/get-students.ts
@@ -76,8 +76,10 @@ export const getStudents = [
 
     const paginatedStudents = filteredStudents.slice(startIndex, startIndex + pageSize);
 
-    const availableGrades = [...new Set(MOCK_STUDENTS.map((s) => s.grade))].sort();
-    const availableClasses = [...new Set(MOCK_STUDENTS.map((s) => s.classNumber))].sort();
+    const availableGrades = [...new Set(MOCK_STUDENTS.map((s) => s.grade))].sort((a, b) => a - b);
+    const availableClasses = [...new Set(MOCK_STUDENTS.map((s) => s.classNumber))].sort(
+      (a, b) => a - b,
+    );
 
     return HttpResponse.json(
       {

--- a/src/shared/components/ui/modal/delete-confirm-modal.tsx
+++ b/src/shared/components/ui/modal/delete-confirm-modal.tsx
@@ -39,6 +39,7 @@ export default function DeleteConfirmModal({
             shape="rect"
             className="flex flex-1 items-center justify-center"
             onClick={handleCancel}
+            data-testid="modal-cancel-button"
           >
             <span className="text-label-18 text-gray-4">취소</span>
           </Button>


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-434]

## 🌱 주요 변경 사항

1. icon, 인터섹션 옵저버를 위한 jest 설정 추가
2. 학생 관리 페이지 내의 컴포넌트 코드에 테스트를 위한 testid 추가
3. manage-student 테스트 코드 작성 및 테스트 진행


## 📌 ManageStudent 테스트 시나리오
1. 기본 렌더링 → "학생 관리" 화면과 버튼들이 정상 표시된다.

2. 학생 목록 표시 → 헤더(학년/반/번호/이름/생활기록부 관리 항목)가 보인다.

3. 학생 선택 → 체크박스 선택 시 "총 N명의 학생 선택" 문구가 표시된다.

4. 여러 학생 선택 → 1명/2명/3명 선택 시 각각 문구가 반영된다.

5. 전체 선택 → 헤더 체크박스 클릭 시 모든 학생이 선택된다.

6. 선택 취소 → "취소" 버튼 클릭 시 선택이 해제된다.

7. 삭제 모달 → "삭제" 클릭 시 모달 열리고, "취소" 클릭 시 닫히며 선택 유지된다.

8. 삭제 실행 → 모달에서 "삭제" 클릭 시 모달 닫히고 선택 해제된다.

9. 필터 버튼 → 클릭 시 "학년/반/생기부 관리 항목" 옵션이 표시된다.

10. 학년 필터 → 선택 시 해당 학년 학생만 보인다.

11. 반 필터 → 선택 시 해당 반 학생만 보인다.

12. 항목 필터 → 선택 시 세특·행발 태그 가진 학생만 보인다.

13. 학생 추가 버튼 → 클릭 시 입력 폼(4개 필드)이 나타난다.

14. 추가 폼 취소 → "취소" 클릭 시 입력 폼이 사라진다.

15. 학생 추가 → 학년/반/번호/이름 입력 후 추가 시 학생이 등록된다.

16. 중복 추가 → 이미 등록된 학생이면 "이미 등록된 학생입니다." 알림이 뜬다.

17. 입력 누락 → 학년 미입력 시 "학년을 입력해주세요." 알림이 뜬다.

18. 엑셀 업로드 버튼 → 클릭 시 업로드 모달이 열린다.

19. 템플릿 다운로드 → 클릭 시 엑셀 템플릿이 다운로드된다.

20. 유효한 파일 업로드 → 파일 이름 표시되고 "학생 리스트 생성" 버튼이 활성화된다.

21. 학생 리스트 생성 → 클릭 시 성공 메시지와 함께 모달이 닫힌다.



[EDMT-434]: https://bbangbbangz.atlassian.net/browse/EDMT-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 없음 (사용자 기능 변화 없음)
- Tests
  - ManageStudent 전체 사용자 흐름 테스트 스위트 추가(렌더링·선택·삭제·필터·추가·엑셀 업로드).
  - Jest 테스트 설정에 SVG 모킹 매핑 추가 및 아이콘·라우팅·인증·IntersectionObserver 모킹과 전역 테스트 헬퍼(clearAllTestMocks 등) 도입으로 테스트 안정성 향상.
- Chores
  - 모의 데이터에 학년/학급 목록 필드 추가로 테스트 시나리오 보강.
- Style
  - 여러 컴포넌트에 data-testid/role 속성 추가(체크박스, 헤더 아이콘, 필터 옵션, 모달 취소 버튼 등).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->