### PR TITLE
[EDMT-438] sse 버그 수정 및 sse 요청 중 다른 학생 페이지로 이동할 때 sse 끊긴다고 알려주는 modal 구현

### DIFF
--- a/src/domains/record/components/record-write/ai-response.tsx
+++ b/src/domains/record/components/record-write/ai-response.tsx
@@ -19,7 +19,7 @@ export default function AiResponse({
   selectedId,
   onGenerationComplete,
 }: AiResponseProps) {
-  const { streamingData, error, setCompletionCallback } = useSseStream(taskId);
+  const { streamingData, error, setCompletionCallback, clearData } = useSseStream(taskId);
   const [copiedVersions, setCopiedVersions] = useState<Set<number>>(new Set());
 
   useEffect(() => {
@@ -27,8 +27,15 @@ export default function AiResponse({
   }, [onGenerationComplete, setCompletionCallback]);
 
   useEffect(() => {
+    if (error && onGenerationComplete) {
+      onGenerationComplete();
+    }
+  }, [error, onGenerationComplete]);
+
+  useEffect(() => {
     setCopiedVersions(new Set());
-  }, [selectedId]);
+    clearData();
+  }, [selectedId, clearData]);
 
   const isLoading = useMemo(() => {
     if (!isGenerating) return false;

--- a/src/domains/record/components/record-write/characteristic-input.tsx
+++ b/src/domains/record/components/record-write/characteristic-input.tsx
@@ -99,7 +99,7 @@ export default function CharacteristicInput({
       {
         recordId: selectedId,
         request: {
-          byteCount: calculateByte(description),
+          byteCount: bytesLimit,
           prompt: description,
         },
       },

--- a/src/domains/record/components/record-write/navigation-confirm-modal.tsx
+++ b/src/domains/record/components/record-write/navigation-confirm-modal.tsx
@@ -1,0 +1,52 @@
+import Button from '@/shared/components/ui/button/button';
+import Modal from '@/shared/components/ui/modal/modal';
+
+interface NavigationConfirmModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function NavigationConfirmModal({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: NavigationConfirmModalProps) {
+  return (
+    <Modal open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <Modal.Overlay />
+      <Modal.Content aria-describedby={undefined} className="max-w-[787px] rounded-[20px] p-14">
+        <Modal.Close />
+        <Modal.Title className="mb-4 text-title-20 text-gray-black">
+          페이지를 이동하시겠습니까?
+        </Modal.Title>
+        <Modal.Description className="mb-10 text-title-18 text-gray-5">
+          현재 AI 응답을 생성 중입니다. 페이지를 이동하면 진행 중인 작업이 중단됩니다.
+        </Modal.Description>
+
+        <div className="flex items-start gap-6 self-stretch">
+          <Button
+            color="secondary"
+            variant="stroke"
+            size="large"
+            shape="rect"
+            className="flex flex-1 items-center justify-center"
+            onClick={onCancel}
+          >
+            <span className="text-label-18 text-gray-4">취소</span>
+          </Button>
+          <Button
+            className="flex flex-1 items-center justify-center"
+            variant="fill"
+            size="large"
+            shape="rect"
+            color="secondary"
+            onClick={onConfirm}
+          >
+            <span className="text-label-18 text-white">이동</span>
+          </Button>
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/src/domains/record/components/record-write/student-record-write.tsx
+++ b/src/domains/record/components/record-write/student-record-write.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
 
 import { RECORD_TYPE_TITLES } from '@/domains/record/constants/record-type';
 import type { RecordType } from '@/domains/record/types/record';
@@ -13,6 +15,7 @@ import { Icons } from '@/shared/components/ui/icon/icon';
 
 import AiResponse from './ai-response';
 import CharacteristicInput from './characteristic-input';
+import NavigationConfirmModal from './navigation-confirm-modal';
 import RecordSummary from './record-summary';
 import StudentSidebarContent from './student-sidebar-content';
 
@@ -27,11 +30,15 @@ export default function StudentRecordWrite({
   recordId,
   studentName,
 }: StudentRecordWriteProps) {
+  const router = useRouter();
   const [taskId, setTaskId] = useState<string | null>(null);
   const isValidRecordId = recordId && !isNaN(recordId);
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [bytesLimit, setBytesLimit] = useState(recordType === 'career' ? 2100 : 1500);
+  const [showNavigationModal, setShowNavigationModal] = useState(false);
+
+  const [pendingNavigation, setPendingNavigation] = useState<string | null>(null);
 
   const handleTaskIdReceived = (newTaskId: string) => {
     setTaskId(newTaskId);
@@ -44,6 +51,33 @@ export default function StudentRecordWrite({
   const handleGenerationComplete = () => {
     setIsGenerating(false);
   };
+
+  const handleNavigationConfirm = useCallback(() => {
+    if (pendingNavigation) {
+      setTaskId(null);
+      setIsGenerating(false);
+      setShowNavigationModal(false);
+      router.push(pendingNavigation);
+      setPendingNavigation(null);
+    }
+  }, [router, pendingNavigation]);
+
+  const handleNavigationCancel = useCallback(() => {
+    setShowNavigationModal(false);
+    setPendingNavigation(null);
+  }, []);
+
+  const handleSidebarNavigation = useCallback(
+    (url: string) => {
+      if (isGenerating) {
+        setPendingNavigation(url);
+        setShowNavigationModal(true);
+      } else {
+        router.push(url);
+      }
+    },
+    [isGenerating, router],
+  );
 
   return (
     <SidebarProvider defaultOpen={false}>
@@ -95,8 +129,18 @@ export default function StudentRecordWrite({
         <SidebarTrigger className="absolute left-2 top-2 z-10 rounded-lg p-[4px] transition-colors hover:bg-gray-2">
           <Icons.SidebarClose size={24} color="text-gray-5" />
         </SidebarTrigger>
-        <StudentSidebarContent recordType={recordType} currentRecordId={recordId} />
+        <StudentSidebarContent
+          recordType={recordType}
+          currentRecordId={recordId}
+          onNavigate={handleSidebarNavigation}
+        />
       </Sidebar>
+
+      <NavigationConfirmModal
+        isOpen={showNavigationModal}
+        onConfirm={handleNavigationConfirm}
+        onCancel={handleNavigationCancel}
+      />
     </SidebarProvider>
   );
 }

--- a/src/domains/record/components/record-write/student-sidebar-content.tsx
+++ b/src/domains/record/components/record-write/student-sidebar-content.tsx
@@ -48,7 +48,7 @@ export default function StudentSidebarContent({
   const handleStudentClick = (recordId: number, studentName: string) => {
     const params = new URLSearchParams(searchParams);
     params.set('id', recordId.toString());
-    params.set('name', encodeURIComponent(studentName));
+    params.set('name', studentName);
     const url = `?${params.toString()}`;
 
     if (onNavigate) {

--- a/src/domains/record/components/record-write/student-sidebar-content.tsx
+++ b/src/domains/record/components/record-write/student-sidebar-content.tsx
@@ -16,11 +16,13 @@ import { cn } from '@/shared/lib/utils';
 interface StudentSidebarContentProps {
   recordType: RecordType;
   currentRecordId?: number;
+  onNavigate?: (url: string) => void;
 }
 
 export default function StudentSidebarContent({
   recordType,
   currentRecordId,
+  onNavigate,
 }: StudentSidebarContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -47,7 +49,13 @@ export default function StudentSidebarContent({
     const params = new URLSearchParams(searchParams);
     params.set('id', recordId.toString());
     params.set('name', encodeURIComponent(studentName));
-    router.push(`?${params.toString()}`);
+    const url = `?${params.toString()}`;
+
+    if (onNavigate) {
+      onNavigate(url);
+    } else {
+      router.push(url);
+    }
   };
 
   const handleGradeSelect = (grade: number) => {

--- a/src/domains/record/hooks/use-sse-stream.ts
+++ b/src/domains/record/hooks/use-sse-stream.ts
@@ -13,9 +13,19 @@ export const useSseStream = (taskId: string | null) => {
   const eventSourceRef = useRef<EventSource | null>(null);
   const completionCallbackRef = useRef<(() => void) | null>(null);
   const isCompletedRef = useRef(false);
+  const currentTaskIdRef = useRef<string | null>(null);
+
+  const clearData = useCallback(() => {
+    setStreamingData(null);
+    setError(null);
+    isCompletedRef.current = false;
+  }, []);
 
   const closeConnection = useCallback(() => {
     if (eventSourceRef.current) {
+      eventSourceRef.current.removeEventListener('ai-message', handleSseMessage);
+      eventSourceRef.current.onopen = null;
+      eventSourceRef.current.onerror = null;
       eventSourceRef.current.close();
       eventSourceRef.current = null;
     }
@@ -24,6 +34,10 @@ export const useSseStream = (taskId: string | null) => {
 
   const handleSseMessage = useCallback(
     (event: MessageEvent) => {
+      if (currentTaskIdRef.current !== taskId) {
+        return;
+      }
+
       try {
         const message: SseMessage = JSON.parse(event.data);
 
@@ -88,39 +102,40 @@ export const useSseStream = (taskId: string | null) => {
         setError('메시지 파싱 오류가 발생했습니다.');
       }
     },
-    [closeConnection],
+    [taskId, closeConnection],
   );
 
   const handleSseError = useCallback(() => {
-    if (isCompletedRef.current) {
+    if (isCompletedRef.current || currentTaskIdRef.current !== taskId) {
       return;
     }
 
     setError('연결 오류가 발생했습니다.');
     closeConnection();
-  }, [closeConnection]);
+  }, [taskId, closeConnection]);
 
   const handleSseOpen = useCallback(() => {
-    setIsConnected(true);
-    setError(null);
-    isCompletedRef.current = false;
-  }, []);
+    if (currentTaskIdRef.current === taskId) {
+      setIsConnected(true);
+      setError(null);
+      isCompletedRef.current = false;
+    }
+  }, [taskId]);
 
   const buildSseUrl = useCallback((taskId: string): string => {
     const isMock = process.env.NEXT_PUBLIC_API_MOCKING === 'enabled';
     const endpoint = `/api/v2/student-records/stream/${taskId}`;
 
     if (isMock) return endpoint;
-
     return `${process.env.NEXT_PUBLIC_API_URL}${endpoint}`;
   }, []);
 
   const connect = useCallback(
     (taskId: string) => {
       closeConnection();
-      setStreamingData(null);
-      setError(null);
-      isCompletedRef.current = false;
+      clearData();
+
+      currentTaskIdRef.current = taskId;
 
       try {
         const url = buildSseUrl(taskId);
@@ -141,24 +156,32 @@ export const useSseStream = (taskId: string | null) => {
         setError('연결을 시작할 수 없습니다.');
       }
     },
-    [closeConnection, buildSseUrl, handleSseMessage, handleSseOpen, handleSseError],
+    [closeConnection, clearData, buildSseUrl, handleSseMessage, handleSseOpen, handleSseError],
   );
 
   useEffect(() => {
-    if (taskId) {
+    if (taskId && taskId !== currentTaskIdRef.current) {
       connect(taskId);
-    } else {
+    } else if (!taskId && currentTaskIdRef.current) {
       closeConnection();
-      setStreamingData(null);
-      setError(null);
-      isCompletedRef.current = false;
+      clearData();
+      currentTaskIdRef.current = null;
     }
 
     return () => {
-      closeConnection();
-      isCompletedRef.current = false;
+      if (!taskId) {
+        closeConnection();
+        currentTaskIdRef.current = null;
+      }
     };
-  }, [taskId, connect, closeConnection]);
+  }, [taskId, connect, closeConnection, clearData]);
+
+  useEffect(() => {
+    return () => {
+      closeConnection();
+      currentTaskIdRef.current = null;
+    };
+  }, [closeConnection]);
 
   const setCompletionCallback = useCallback((callback: (() => void) | null) => {
     completionCallbackRef.current = callback;
@@ -171,5 +194,6 @@ export const useSseStream = (taskId: string | null) => {
     connect,
     closeConnection,
     setCompletionCallback,
+    clearData,
   };
 };


### PR DESCRIPTION
## 📌 연관된 이슈 번호

[EDMT-438]

## 🌱 주요 변경 사항

1. 기존 sse 로직에서 Url 변경 시 이전 taskId로 연결되어 있던 sse 요청으로 인해 새로 sse 요청을 할 때 응답이 오지 않는 버그 수정
2. sse 요청 중 다른 학생 페이지로 넘어갈 때 AiResponse 그대로 요청중이라고 보이는 버그 수정
3. 학생 특성 기입란에서 byteCount를 설정한 ByteLimit가 아닌 현재 작성한 특성의 byte로 요청이 가는 버그 수정
4. sse 요청 중 사이드바로 다른 학생 페이지로 이동할 때 정말 sse 연결을 끊고 이동할건지 물어보는 modal 컴포넌트 구현
5. sse 요청 중 사이드바로 다른 학생 페이지로 이동할 때 정말 sse 연결을 끊고 이동할건지 물어보는 modal 컴포넌트 RecordWrite 컴포넌트와 연동


[EDMT-438]: https://bbangbbangz.atlassian.net/browse/EDMT-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - AI 생성 중 페이지 이동 시 확인 모달을 표시해 이동/취소를 선택할 수 있습니다.

- 개선
  - AI 생성 요청이 설명 길이와 무관하게 사용자가 지정한 글자 수 한도로 전송됩니다.
  - 사이드바 탐색 흐름이 향상되어 생성 중인 경우 이동을 일시 보류하고 확인 후 진행합니다.

- 버그 수정
  - 스트리밍 상태 초기화와 오류 처리 로직을 강화해 작업 간 데이터 혼입을 방지합니다.
  - 생성 중 오류 발생 시 등록된 완료 콜백이 안정적으로 호출되도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->